### PR TITLE
Added setupConsensus method to set the consensus address

### DIFF
--- a/contracts/anchor/Anchor.sol
+++ b/contracts/anchor/Anchor.sol
@@ -64,12 +64,12 @@ contract Anchor is AnchorI, ConsensusModule, CircularBufferUint {
         uint256 _blockHeight,
         bytes32 _stateRoot,
         uint256 _maxStateRoots,
-        address _consensus
+        ConsensusI _consensus
     )
         CircularBufferUint(_maxStateRoots)
         public
     {
-        consensus = ConsensusI(_consensus);
+        setup(_consensus);
         stateRoots[_blockHeight] = _stateRoot;
         CircularBufferUint.store(_blockHeight);
     }

--- a/contracts/anchor/Anchor.sol
+++ b/contracts/anchor/Anchor.sol
@@ -69,7 +69,7 @@ contract Anchor is AnchorI, ConsensusModule, CircularBufferUint {
         CircularBufferUint(_maxStateRoots)
         public
     {
-        setup(_consensus);
+        setupConsensus(_consensus);
         stateRoots[_blockHeight] = _stateRoot;
         CircularBufferUint.store(_blockHeight);
     }

--- a/contracts/axiom/Axiom.sol
+++ b/contracts/axiom/Axiom.sol
@@ -280,7 +280,7 @@ contract Axiom is AxiomI, ProxyFactory, ConsensusModule {
             blockHeader.height,
             blockHeader.stateRoot,
             _maxStateRoots,
-            address(consensus)
+            consensus
         );
 
         consensus.newMetaChain(

--- a/contracts/axiom/Axiom.sol
+++ b/contracts/axiom/Axiom.sol
@@ -184,7 +184,7 @@ contract Axiom is AxiomI, ProxyFactory, ConsensusModule {
         // which is deployed in next step.
         Proxy consensusProxy = createProxy(consensusMasterCopy, "");
 
-        consensus = ConsensusI(address(consensusProxy));
+        setupConsensus(ConsensusI(address(consensusProxy)));
 
         bytes memory reputationSetupData = abi.encodeWithSelector(
             REPUTATION_SETUP_CALLPREFIX,

--- a/contracts/committee/Committee.sol
+++ b/contracts/committee/Committee.sol
@@ -259,7 +259,7 @@ contract Committee is MasterCopyNonUpgradable, ConsensusModule, CommitteeI {
             "Proposal must not be zero."
         );
 
-        setupConsensus(_consensus);
+        setup(_consensus);
 
         committeeStatus = CommitteeStatus.Open;
 

--- a/contracts/committee/Committee.sol
+++ b/contracts/committee/Committee.sol
@@ -232,7 +232,7 @@ contract Committee is MasterCopyNonUpgradable, ConsensusModule, CommitteeI {
     /* External functions */
 
     function setup(
-        address _consensus,
+        ConsensusI _consensus,
         uint256 _committeeSize,
         bytes32 _dislocation,
         bytes32 _proposal
@@ -259,7 +259,7 @@ contract Committee is MasterCopyNonUpgradable, ConsensusModule, CommitteeI {
             "Proposal must not be zero."
         );
 
-        consensus = ConsensusI(_consensus);
+        setupConsensus(_consensus);
 
         committeeStatus = CommitteeStatus.Open;
 

--- a/contracts/committee/Committee.sol
+++ b/contracts/committee/Committee.sol
@@ -259,7 +259,7 @@ contract Committee is MasterCopyNonUpgradable, ConsensusModule, CommitteeI {
             "Proposal must not be zero."
         );
 
-        setup(_consensus);
+        setupConsensus(_consensus);
 
         committeeStatus = CommitteeStatus.Open;
 

--- a/contracts/consensus/ConsensusModule.sol
+++ b/contracts/consensus/ConsensusModule.sol
@@ -21,6 +21,16 @@ contract ConsensusModule {
     /** Consensus contract for which this committee was formed. */
     ConsensusI public consensus;
 
+    /**
+     * @notice It sets address for consensus contract.
+     * @param _consensus Address of consensus contract.
+     */
+    function setupConsensus(ConsensusI _consensus) public {
+        require(address(consensus) == address(0), "Consensus address is already present.");
+        require(address(_consensus) != address(0), "Address must not be null.");
+        consensus = _consensus;
+    }
+
     modifier onlyConsensus()
     {
         require(

--- a/contracts/consensus/ConsensusModule.sol
+++ b/contracts/consensus/ConsensusModule.sol
@@ -25,9 +25,15 @@ contract ConsensusModule {
      * @notice It sets address for consensus contract.
      * @param _consensus Address of consensus contract.
      */
-    function setupConsensus(ConsensusI _consensus) public {
-        require(address(consensus) == address(0), "Consensus address is already present.");
-        require(address(_consensus) != address(0), "Address must not be null.");
+    function setup(ConsensusI _consensus) public {
+        require(
+            address(consensus) == address(0),
+            "Consensus address is already present."
+        );
+        require(
+            address(_consensus) != address(0),
+            "Consensus address must not be null."
+        );
         consensus = _consensus;
     }
 

--- a/contracts/consensus/ConsensusModule.sol
+++ b/contracts/consensus/ConsensusModule.sol
@@ -25,7 +25,7 @@ contract ConsensusModule {
      * @notice It sets address for consensus contract.
      * @param _consensus Address of consensus contract.
      */
-    function setup(ConsensusI _consensus) public {
+    function setupConsensus(ConsensusI _consensus) public {
         require(
             address(consensus) == address(0),
             "Consensus address is already present."

--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -262,7 +262,7 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
     /* External and public functions */
 
     function setup(
-        address _consensus,
+        ConsensusI _consensus,
         bytes20 _chainId,
         uint256 _epochLength,
         uint256 _minValidators,
@@ -294,7 +294,7 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
             )
         );
 
-        consensus = ConsensusI(_consensus);
+        setup(_consensus);
 
         coreStatus = CoreStatus.creation;
 

--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -294,7 +294,7 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
             )
         );
 
-        setup(_consensus);
+        setupConsensus(_consensus);
 
         coreStatus = CoreStatus.creation;
 

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -214,11 +214,6 @@ contract Reputation is ConsensusModule {
         );
 
         require(
-            _consensus != address(0),
-            "consensus address is 0."
-        );
-
-        require(
             _mOST != ERC20I(0),
             "mOST token address is 0."
         );
@@ -248,7 +243,7 @@ contract Reputation is ConsensusModule {
             "Withdrawal cooldown period in blocks must be greater than zero."
         );
 
-        consensus = ConsensusI(_consensus);
+        setup(_consensus);
         mOST = ERC20I(_mOST);
         wETH = ERC20I(_wETH);
         stakeMOSTAmount = _stakeMOSTAmount;

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -243,7 +243,7 @@ contract Reputation is ConsensusModule {
             "Withdrawal cooldown period in blocks must be greater than zero."
         );
 
-        setup(_consensus);
+        setupConsensus(_consensus);
         mOST = ERC20I(_mOST);
         wETH = ERC20I(_wETH);
         stakeMOSTAmount = _stakeMOSTAmount;

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -181,7 +181,7 @@ contract Reputation is ConsensusModule {
      *          - a cashable earnings per mille is in [0, 1000] range
      */
     function setup(
-        address _consensus,
+        ConsensusI _consensus,
         address _mOST,
         uint256 _stakeMOSTAmount,
         address _wETH,
@@ -222,7 +222,7 @@ contract Reputation is ConsensusModule {
             "Cashable earnings is not in valid range: [0, 1000]."
         );
 
-        consensus = ConsensusI(_consensus);
+        setup(_consensus);
         mOST = EIP20I(_mOST);
         wETH = EIP20I(_wETH);
         stakeMOSTAmount = _stakeMOSTAmount;

--- a/contracts/test/consensus/MockConsensus.sol
+++ b/contracts/test/consensus/MockConsensus.sol
@@ -48,7 +48,7 @@ contract MockConsensus is ConsensusI, ReputationI {
     {
         core = new Core();
         core.setup(
-            address(this),
+            ConsensusI(this),
             _chainId,
             _epochLength,
             MIN_VALIDATOR,

--- a/test/consensus/setup.js
+++ b/test/consensus/setup.js
@@ -22,7 +22,7 @@ const AxiomUtils = require('../axiom/utils');
 
 const Consensus = artifacts.require('Consensus');
 
-contract('Consensus::setup', (accounts) => {
+contract('Consensus::setupConsensus', (accounts) => {
   const accountProvider = new AccountProvider(accounts);
   let setupParams = {};
   let consensus;
@@ -50,7 +50,7 @@ contract('Consensus::setup', (accounts) => {
         { committeeSize: new BN(0) },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setup(consensus, params),
+        ConsensusUtils.setupConsensus(consensus, params),
         'Committee size is 0.',
       );
     });
@@ -62,7 +62,7 @@ contract('Consensus::setup', (accounts) => {
         { minValidators: new BN(4) },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setup(consensus, params),
+        ConsensusUtils.setupConsensus(consensus, params),
         'Min validator size must be greater or equal to 5.',
       );
     });
@@ -74,7 +74,7 @@ contract('Consensus::setup', (accounts) => {
         { joinLimit: new BN(3) },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setup(consensus, params),
+        ConsensusUtils.setupConsensus(consensus, params),
         'Max validator size is less than minimum validator size.',
       );
     });
@@ -86,7 +86,7 @@ contract('Consensus::setup', (accounts) => {
         { gasTargetDelta: new BN(0) },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setup(consensus, params),
+        ConsensusUtils.setupConsensus(consensus, params),
         'Gas target delta is 0.',
       );
     });
@@ -98,7 +98,7 @@ contract('Consensus::setup', (accounts) => {
         { coinbaseSplitPerMille: new BN(1001) },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setup(consensus, params),
+        ConsensusUtils.setupConsensus(consensus, params),
         'Coin base split per mille should be in range: 0..1000.',
       );
     });
@@ -110,15 +110,15 @@ contract('Consensus::setup', (accounts) => {
         { reputation: Utils.NULL_ADDRESS },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setup(consensus, params),
+        ConsensusUtils.setupConsensus(consensus, params),
         'Reputation contract address is 0.',
       );
     });
 
     it('should fail when consensus contract is already setup', async () => {
-      await ConsensusUtils.setup(consensus, setupParams);
+      await ConsensusUtils.setupConsensus(consensus, setupParams);
       await Utils.expectRevert(
-        ConsensusUtils.setup(consensus, setupParams),
+        ConsensusUtils.setupConsensus(consensus, setupParams),
         'Consensus is already setup.',
       );
     });
@@ -126,7 +126,7 @@ contract('Consensus::setup', (accounts) => {
 
   contract('Positive Tests', () => {
     it('should set the variables', async () => {
-      await ConsensusUtils.setup(consensus, setupParams);
+      await ConsensusUtils.setupConsensus(consensus, setupParams);
 
       const committeeSize = await consensus.committeeSize.call();
       assert.strictEqual(

--- a/test/consensus/setup.js
+++ b/test/consensus/setup.js
@@ -22,7 +22,7 @@ const AxiomUtils = require('../axiom/utils');
 
 const Consensus = artifacts.require('Consensus');
 
-contract('Consensus::setupConsensus', (accounts) => {
+contract('Consensus::setup', (accounts) => {
   const accountProvider = new AccountProvider(accounts);
   let setupParams = {};
   let consensus;
@@ -50,7 +50,7 @@ contract('Consensus::setupConsensus', (accounts) => {
         { committeeSize: new BN(0) },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setupConsensus(consensus, params),
+        ConsensusUtils.setup(consensus, params),
         'Committee size is 0.',
       );
     });
@@ -62,7 +62,7 @@ contract('Consensus::setupConsensus', (accounts) => {
         { minValidators: new BN(4) },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setupConsensus(consensus, params),
+        ConsensusUtils.setup(consensus, params),
         'Min validator size must be greater or equal to 5.',
       );
     });
@@ -74,7 +74,7 @@ contract('Consensus::setupConsensus', (accounts) => {
         { joinLimit: new BN(3) },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setupConsensus(consensus, params),
+        ConsensusUtils.setup(consensus, params),
         'Max validator size is less than minimum validator size.',
       );
     });
@@ -86,7 +86,7 @@ contract('Consensus::setupConsensus', (accounts) => {
         { gasTargetDelta: new BN(0) },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setupConsensus(consensus, params),
+        ConsensusUtils.setup(consensus, params),
         'Gas target delta is 0.',
       );
     });
@@ -98,7 +98,7 @@ contract('Consensus::setupConsensus', (accounts) => {
         { coinbaseSplitPerMille: new BN(1001) },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setupConsensus(consensus, params),
+        ConsensusUtils.setup(consensus, params),
         'Coin base split per mille should be in range: 0..1000.',
       );
     });
@@ -110,15 +110,15 @@ contract('Consensus::setupConsensus', (accounts) => {
         { reputation: Utils.NULL_ADDRESS },
       );
       await Utils.expectRevert(
-        ConsensusUtils.setupConsensus(consensus, params),
+        ConsensusUtils.setup(consensus, params),
         'Reputation contract address is 0.',
       );
     });
 
     it('should fail when consensus contract is already setup', async () => {
-      await ConsensusUtils.setupConsensus(consensus, setupParams);
+      await ConsensusUtils.setup(consensus, setupParams);
       await Utils.expectRevert(
-        ConsensusUtils.setupConsensus(consensus, setupParams),
+        ConsensusUtils.setup(consensus, setupParams),
         'Consensus is already setup.',
       );
     });
@@ -126,7 +126,7 @@ contract('Consensus::setupConsensus', (accounts) => {
 
   contract('Positive Tests', () => {
     it('should set the variables', async () => {
-      await ConsensusUtils.setupConsensus(consensus, setupParams);
+      await ConsensusUtils.setup(consensus, setupParams);
 
       const committeeSize = await consensus.committeeSize.call();
       assert.strictEqual(

--- a/test/consensus/setup_consensus.js
+++ b/test/consensus/setup_consensus.js
@@ -30,9 +30,8 @@ contract('ConsensusModule::setupConsensus', (accounts) => {
 
   contract('Negative Tests', () => {
     it('should fail to set when consensus address is null', async () => {
-      await consensusModule.setupConsensus(Utils.NULL_ADDRESS);
       await Utils.expectRevert(
-        consensusModule.setupConsensus(consensusAddress),
+        consensusModule.setupConsensus(Utils.NULL_ADDRESS),
         'Address must not be null.',
       );
     });

--- a/test/consensus/setup_consensus.js
+++ b/test/consensus/setup_consensus.js
@@ -39,7 +39,7 @@ contract('ConsensusModule::setupConsensus', (accounts) => {
     it('should fail to set when consensus address is already set', async () => {
       await consensusModule.setupConsensus(consensusAddress);
       await Utils.expectRevert(
-        consensusModule.setup(consensusAddress),
+        consensusModule.setupConsensus(consensusAddress),
         'Consensus address is already present.',
       );
     });

--- a/test/consensus/setup_consensus.js
+++ b/test/consensus/setup_consensus.js
@@ -19,7 +19,7 @@ const Utils = require('../test_lib/utils.js');
 
 const ConsensusModule = artifacts.require('ConsensusModule');
 
-contract('ConsensusModule::setupConsensus', (accounts) => {
+contract('ConsensusModule::setup', (accounts) => {
   const accountProvider = new AccountProvider(accounts);
   let consensusModule;
   let consensusAddress;
@@ -31,15 +31,15 @@ contract('ConsensusModule::setupConsensus', (accounts) => {
   contract('Negative Tests', () => {
     it('should fail to set when consensus address is null', async () => {
       await Utils.expectRevert(
-        consensusModule.setupConsensus(Utils.NULL_ADDRESS),
-        'Address must not be null.',
+        consensusModule.setup(Utils.NULL_ADDRESS),
+        'Consensus address must not be null.',
       );
     });
 
     it('should fail to set when consensus address is already set', async () => {
-      await consensusModule.setupConsensus(consensusAddress);
+      await consensusModule.setup(consensusAddress);
       await Utils.expectRevert(
-        consensusModule.setupConsensus(consensusAddress),
+        consensusModule.setup(consensusAddress),
         'Consensus address is already present.',
       );
     });
@@ -47,7 +47,7 @@ contract('ConsensusModule::setupConsensus', (accounts) => {
 
   contract('Positive Tests', () => {
     it('should set consensus address successfully', async () => {
-      await consensusModule.setupConsensus(consensusAddress);
+      await consensusModule.setup(consensusAddress);
       const actualConsensusAddress = await consensusModule.consensus.call();
       assert.strictEqual(
         actualConsensusAddress,

--- a/test/consensus/setup_consensus.js
+++ b/test/consensus/setup_consensus.js
@@ -31,13 +31,13 @@ contract('ConsensusModule::setup', (accounts) => {
   contract('Negative Tests', () => {
     it('should fail to set when consensus address is null', async () => {
       await Utils.expectRevert(
-        consensusModule.setup(Utils.NULL_ADDRESS),
+        consensusModule.setupConsensus(Utils.NULL_ADDRESS),
         'Consensus address must not be null.',
       );
     });
 
     it('should fail to set when consensus address is already set', async () => {
-      await consensusModule.setup(consensusAddress);
+      await consensusModule.setupConsensus(consensusAddress);
       await Utils.expectRevert(
         consensusModule.setup(consensusAddress),
         'Consensus address is already present.',
@@ -47,7 +47,7 @@ contract('ConsensusModule::setup', (accounts) => {
 
   contract('Positive Tests', () => {
     it('should set consensus address successfully', async () => {
-      await consensusModule.setup(consensusAddress);
+      await consensusModule.setupConsensus(consensusAddress);
       const actualConsensusAddress = await consensusModule.consensus.call();
       assert.strictEqual(
         actualConsensusAddress,

--- a/test/consensus/setup_consensus.js
+++ b/test/consensus/setup_consensus.js
@@ -1,0 +1,60 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const { AccountProvider } = require('../test_lib/utils.js');
+const Utils = require('../test_lib/utils.js');
+
+const ConsensusModule = artifacts.require('ConsensusModule');
+
+contract('ConsensusModule::setupConsensus', (accounts) => {
+  const accountProvider = new AccountProvider(accounts);
+  let consensusModule;
+  let consensusAddress;
+  beforeEach(async () => {
+    consensusModule = await ConsensusModule.new();
+    consensusAddress = accountProvider.get();
+  });
+
+  contract('Negative Tests', () => {
+    it('should fail to set when consensus address is null', async () => {
+      await consensusModule.setupConsensus(Utils.NULL_ADDRESS);
+      await Utils.expectRevert(
+        consensusModule.setupConsensus(consensusAddress),
+        'Address must not be null.',
+      );
+    });
+
+    it('should fail to set when consensus address is already set', async () => {
+      await consensusModule.setupConsensus(consensusAddress);
+      await Utils.expectRevert(
+        consensusModule.setupConsensus(consensusAddress),
+        'Consensus address is already present.',
+      );
+    });
+  });
+
+  contract('Positive Tests', () => {
+    it('should set consensus address successfully', async () => {
+      await consensusModule.setupConsensus(consensusAddress);
+      const actualConsensusAddress = await consensusModule.consensus.call();
+      assert.strictEqual(
+        actualConsensusAddress,
+        consensusAddress,
+        'Incorrect consensus address',
+      );
+    });
+  });
+});

--- a/test/consensus/setup_consensus.js
+++ b/test/consensus/setup_consensus.js
@@ -19,7 +19,7 @@ const Utils = require('../test_lib/utils.js');
 
 const ConsensusModule = artifacts.require('ConsensusModule');
 
-contract('ConsensusModule::setup', (accounts) => {
+contract('ConsensusModule::setupConsensus', (accounts) => {
   const accountProvider = new AccountProvider(accounts);
   let consensusModule;
   let consensusAddress;

--- a/test/reputation/setup.js
+++ b/test/reputation/setup.js
@@ -124,7 +124,7 @@ contract('Reputation::setup', (accounts) => {
         constructorArgs.initialReputation,
         constructorArgs.withdrawalCooldownPeriodInBlocks,
       ),
-      'consensus address is 0.',
+      'Consensus address must not be null.',
     );
   });
 


### PR DESCRIPTION
PR contains changes to add
1.  setupConsensus method in ConsensusModule contract.
2. Usage of setupConsensus method in Committee contract.
3. Unit test cases for setupConsensus method.


fixes #28 