### PR TITLE
Implementation of Reputation.isActiveValidator

### DIFF
--- a/contracts/consensus/Consensus.sol
+++ b/contracts/consensus/Consensus.sol
@@ -125,7 +125,7 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
     modifier onlyValidator()
     {
         require(
-            reputation.isActive(msg.sender),
+            reputation.isActiveValidator(msg.sender),
             "Validator must be active in the reputation contract."
         );
 
@@ -340,7 +340,7 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
         );
 
         require(
-            reputation.isActive(_validator),
+            reputation.isActiveValidator(_validator),
             "Validator is not active."
         );
 

--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -537,7 +537,7 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
             "Validator must be active in this core."
         );
         require(
-            reputation.isActive(validator),
+            reputation.isActiveValidator(validator),
             "Validator must be active."
         );
 

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -103,7 +103,7 @@ contract Reputation is ConsensusModule {
     modifier isActive(address _validator)
     {
         require(
-            validators[_validator].status == ValidatorStatus.Staked,
+            isActiveValidator(_validator),
             "Validator is not active."
         );
 
@@ -570,5 +570,19 @@ contract Reputation is ConsensusModule {
         returns (uint256)
     {
         return validators[_validator].reputation;
+    }
+
+    /**
+     * @notice Check if the validator address is active or not.
+     *
+     * @param _validator An address of a validator.
+     * Returns true if the specified address is an active validator.
+     */
+    function isActiveValidator(address _validator)
+        public
+        view
+        returns(bool)
+    {
+        return validators[_validator].status == ValidatorStatus.Staked;
     }
 }

--- a/contracts/reputation/ReputationI.sol
+++ b/contracts/reputation/ReputationI.sol
@@ -16,7 +16,7 @@ pragma solidity ^0.5.0;
 
 interface ReputationI {
 
-    function isActive(address _validator) external view returns (bool);
+    function isActiveValidator(address _validator) external view returns (bool);
 
     function join(
         address _validator,

--- a/contracts/test/consensus/MockConsensus.sol
+++ b/contracts/test/consensus/MockConsensus.sol
@@ -101,8 +101,8 @@ contract MockConsensus is ConsensusI, ReputationI {
         mockCore.removeVote(_validator);
     }
 
-    function isActive(address _validator)
-        external
+    function isActiveValidator(address _validator)
+        public
         view
         returns (bool)
     {

--- a/contracts/test/reputation/SpyReputation.sol
+++ b/contracts/test/reputation/SpyReputation.sol
@@ -45,10 +45,10 @@ contract SpyReputation is MasterCopyNonUpgradable, ReputationI {
         activeValidators[_validator] = _active;
     }
 
-    function isActive(
+    function isActiveValidator(
         address _validator
     )
-        external
+        public
         view
         returns (bool)
     {


### PR DESCRIPTION
External method isActive is declared in Reputation interface. However this method is not implemented in Reputation contract.

**Proposal**

There is already an implementation of `isActive modifier` in reputation contract. Proposal is to implement `Reputation.isActiveValidator` method. `isActive modifier` should call  isActiveValidator method.

**Method Signature**
```
function isActiveValidator(address _validator)
        public
        view
        returns(bool)
    {}
```

Fixes #64 