### PR TITLE
Reputation contract improvements

### DIFF
--- a/contracts/consensus/Consensus.sol
+++ b/contracts/consensus/Consensus.sol
@@ -122,16 +122,6 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
 
     /* Modifiers */
 
-    modifier onlyValidator()
-    {
-        require(
-            !reputation.isSlashed(msg.sender),
-            "Validator is slashed."
-        );
-
-        _;
-    }
-
     modifier onlyCore()
     {
         require(

--- a/contracts/consensus/Consensus.sol
+++ b/contracts/consensus/Consensus.sol
@@ -510,8 +510,8 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
             "Core status is not opened or precommitted."
         );
 
-        // Join in reputation contract.
-        reputation.join(msg.sender, _withdrawalAddress);
+        // Stake in reputation contract.
+        reputation.stake(msg.sender, _withdrawalAddress);
 
         // Join in core contract.
         CoreI(_core).join(msg.sender);
@@ -545,8 +545,8 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
             "Core must be in an active state."
         );
 
-        // Join in reputation contract.
-        reputation.join(msg.sender, _withdrawalAddress);
+        // Stake in reputation contract.
+        reputation.stake(msg.sender, _withdrawalAddress);
 
         // Join in core contract.
         CoreI(_core).joinDuringCreation(msg.sender);

--- a/contracts/consensus/Consensus.sol
+++ b/contracts/consensus/Consensus.sol
@@ -125,8 +125,8 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
     modifier onlyValidator()
     {
         require(
-            reputation.isActiveValidator(msg.sender),
-            "Validator must be active in the reputation contract."
+            !reputation.isSlashed(msg.sender),
+            "Validator is slashed."
         );
 
         _;
@@ -319,9 +319,9 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
      * @notice Enter a validator into the committee.
      *
      * @dev Function requires:
-     *          - committee address should be present.
-     *          - validator should be active.
-     *          - validator successfully enter a committee.
+     *          - committee address should be present
+     *          - validator should not be slashed in reputation contract
+     *          - validator successfully enter a committee
      *
      * @param _committeeAddress Committee address that validator wants to enter.
      * @param _validator Validator address to enter.
@@ -340,8 +340,8 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
         );
 
         require(
-            reputation.isActiveValidator(_validator),
-            "Validator is not active."
+            !reputation.isSlashed(_validator),
+            "Validator is slashed."
         );
 
         CommitteeI committee = CommitteeI(_committeeAddress);

--- a/contracts/consensus/Consensus.sol
+++ b/contracts/consensus/Consensus.sol
@@ -125,7 +125,7 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
     modifier onlyValidator()
     {
         require(
-            reputation.isActive(msg.sender),
+            reputation.isActiveValidator(msg.sender),
             "Validator must be active in the reputation contract."
         );
 
@@ -340,7 +340,7 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
         );
 
         require(
-            reputation.isActive(_validator),
+            reputation.isActiveValidator(_validator),
             "Validator is not active."
         );
 

--- a/contracts/consensus/Consensus.sol
+++ b/contracts/consensus/Consensus.sol
@@ -591,7 +591,7 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
         );
 
         CoreI(_core).logout(msg.sender);
-        reputation.logout(msg.sender);
+        reputation.deregister(msg.sender);
     }
 
     /**

--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -537,7 +537,7 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
             "Validator must be active in this core."
         );
         require(
-            reputation.isActive(validator),
+            reputation.isActiveValidator(validator),
             "Validator must be active."
         );
 

--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -501,7 +501,7 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
      *          - if core has precommitted, the given proposal matches with it
      *          - proposal exists at open kernel height
      *          - validator active in this core
-     *          - validator is active
+     *          - validator should not be slashed in reputation contract
      *          - validator has not already cast the same vote
      *          - vote gets updated only if the new vote is at higher dynsaty
      */
@@ -537,8 +537,8 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
             "Validator must be active in this core."
         );
         require(
-            reputation.isActiveValidator(validator),
-            "Validator must be active."
+            !reputation.isSlashed(validator),
+            "Validator is slashed."
         );
 
         bytes32 castVote = votes[validator];

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -407,7 +407,7 @@ contract Reputation is ConsensusModule {
      * @param _validator A validator address to join.
      * @param _withdrawalAddress A withdrawal address of newly joined validator.
      */
-    function stake(
+    function join(
         address _validator,
         address _withdrawalAddress
     )

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -50,7 +50,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
         Staked,
 
         /** Validator has deregistered and no longer participates in consensus */
-        DeRegistered,
+        Deregistered,
 
         /** Validator has withdrawn stake after deregistering and cooldown period */
         Withdrawn
@@ -131,10 +131,10 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
         _;
     }
 
-    modifier hasDeRegistered(address _validator)
+    modifier hasDeregistered(address _validator)
     {
         require(
-            validators[_validator].status >= ValidatorStatus.DeRegistered,
+            validators[_validator].status >= ValidatorStatus.Deregistered,
             "Validator has not deregistered."
         );
 
@@ -505,7 +505,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
     {
         ValidatorInfo storage v = validators[_validator];
 
-        v.status = ValidatorStatus.DeRegistered;
+        v.status = ValidatorStatus.Deregistered;
 
         v.withdrawalBlockHeight = block.number.add(
             withdrawalCooldownPeriodInBlocks
@@ -525,7 +525,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
      */
     function withdraw(address _validator)
         external
-        hasDeRegistered(_validator)
+        hasDeregistered(_validator)
         isHonest(_validator)
         hasNotWithdrawn(_validator)
         withdrawalCooldownPeriodHasElapsed(_validator)

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -103,7 +103,7 @@ contract Reputation is ConsensusModule {
     modifier isActive(address _validator)
     {
         require(
-            validators[_validator].status == ValidatorStatus.Staked,
+            isActiveValidator(_validator),
             "Validator is not active."
         );
 
@@ -570,5 +570,19 @@ contract Reputation is ConsensusModule {
         returns (uint256)
     {
         return validators[_validator].reputation;
+    }
+
+    /**
+     * @notice Check if the validator address is active or not.
+     *
+     * @param _validator An address of a validator.
+     * Returns true if the specified address is an active validator.
+     */
+    function isActiveValidator(address _validator)
+        public
+        view
+        returns(bool)
+    {
+        return validators[_validator].status == ValidatorStatus.Staked;
     }
 }

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -76,16 +76,16 @@ contract Reputation is ConsensusModule {
     /** ERC20 wETH for stakes for validators. */
     ERC20I public wETH;
 
-    /** Required stake amount in mOST to join as a validator. */
+    /** Required stake amount in mOST to stake as a validator. */
     uint256 public stakeMOSTAmount;
 
-    /** Required stake amount in wETH to join as a validator. */
+    /** Required stake amount in wETH to stake as a validator. */
     uint256 public stakeWETHAmount;
 
     /** A per mille of earnings that validator can cash out immediately. */
     uint256 public cashableEarningsPerMille;
 
-    /** An initial reputation for a newly joined validator. */
+    /** An initial reputation for a newly staked validator. */
     uint256 public initialReputation;
 
     /**
@@ -110,11 +110,11 @@ contract Reputation is ConsensusModule {
         _;
     }
 
-    modifier hasJoined(address _validator)
+    modifier hasStaked(address _validator)
     {
         require(
             validators[_validator].status != ValidatorStatus.Undefined,
-            "Validator has not joined."
+            "Validator has not staked."
         );
 
         _;
@@ -177,21 +177,21 @@ contract Reputation is ConsensusModule {
      * @dev Function requires:
      *          - mOST token address is not 0
      *          - wETH token address is not 0
-     *          - a stake amount to join in mOST is positive
-     *          - a stake amount to join in wETH is positive
+     *          - a stake amount to stake in mOST is positive
+     *          - a stake amount to stake in wETH is positive
      *          - a cashable earnings per mille is in [0, 1000] range
      *
      * @param _consensus Address of consensus contract.
      * @param _mOST Address of EIP20 mOST token.
      * @param _stakeMOSTAmount Amount of mOST token in wei required to be
-     *                         staked by each validator on join.
+     *                         staked by each validator on staking.
      * @param _wETH Address of EIP20 wETH token.
      * @param _stakeWETHAmount Amount of wETH token in wei required to be
-     *                         staked by each validator on join.
+     *                         staked by each validator on staking.
      * @param _cashableEarningsPerMille Number ranging from [0-1000] which
      *                                  defines cashable earning per mille.
      * @param _initialReputation Initial reputation assigned when a validator
-     *                           joins.
+     *                           stakes.
      * @param _withdrawalCooldownPeriodInBlocks Defines block delay between
      *                                          deregister and withdraw operation
      *                                          for a validator.
@@ -225,12 +225,12 @@ contract Reputation is ConsensusModule {
 
         require(
             _stakeMOSTAmount > 0,
-            "Stake amount to join in mOST is not positive."
+            "Stake amount in mOST is not positive."
         );
 
         require(
             _stakeWETHAmount > 0,
-            "Stake amount to join in wETH is not positive."
+            "Stake amount in wETH is not positive."
         );
 
         require(
@@ -356,7 +356,7 @@ contract Reputation is ConsensusModule {
      *
      * @dev Function requires:
      *          - only validator can call
-     *          - validator has joined
+     *          - validator has staked
      *          - validator was not slashed
      *          - validator has not withdrawn
      *          - the specified amount is not bigger than cashable earnings
@@ -366,7 +366,7 @@ contract Reputation is ConsensusModule {
      */
     function cashOutEarnings(uint256 _amount)
         external
-        hasJoined(msg.sender)
+        hasStaked(msg.sender)
         isHonest(msg.sender)
         hasNotWithdrawn(msg.sender)
     {
@@ -390,24 +390,24 @@ contract Reputation is ConsensusModule {
     }
 
     /**
-     * @notice Joins a validator.
+     * @notice Stakes a validator.
      *
      * @dev Function requires:
      *          - only consensus can call
      *          - a validator address is not 0
      *          - a withdrawal address is not 0
      *          - a validator address is not same as its withdrawal address
-     *          - a validator has not joined previously
+     *          - a validator has not staked previously
      *          - a withdrawal address has not been used as a validator address
      *          - a validator approved in mOST token contract to transfer
      *            a stake amount.
      *          - a validator approved in wETH token contract to transfer
      *            a stake amount.
      *
-     * @param _validator A validator address to join.
-     * @param _withdrawalAddress A withdrawal address of newly joined validator.
+     * @param _validator A validator address to stake.
+     * @param _withdrawalAddress A withdrawal address of newly staked validator.
      */
-    function join(
+    function stake(
         address _validator,
         address _withdrawalAddress
     )
@@ -431,7 +431,7 @@ contract Reputation is ConsensusModule {
 
         require(
             validators[_validator].status == ValidatorStatus.Undefined,
-            "No validator can rejoin."
+            "No validator can stake again."
         );
 
         require(
@@ -462,7 +462,7 @@ contract Reputation is ConsensusModule {
      *
      * @dev Function requires:
      *          - only consensus can call
-     *          - a validator has joined
+     *          - a validator has staked
      *          - a validator has not withdrawn
      *
      * @param _validator A validator address to slash.
@@ -470,7 +470,7 @@ contract Reputation is ConsensusModule {
     function slash(address _validator)
         external
         onlyConsensus
-        hasJoined(_validator)
+        hasStaked(_validator)
         hasNotWithdrawn(_validator)
         hasNotSlashed(_validator)
     {

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -103,7 +103,7 @@ contract Reputation is ConsensusModule {
     modifier isActive(address _validator)
     {
         require(
-            isActiveValidator(_validator),
+            validators[_validator].status == ValidatorStatus.Staked,
             "Validator is not active."
         );
 
@@ -573,16 +573,16 @@ contract Reputation is ConsensusModule {
     }
 
     /**
-     * @notice Check if the validator address is active or not.
+     * @notice Check if the validator address is slashed or not.
      *
      * @param _validator An address of a validator.
-     * Returns true if the specified address is an active validator.
+     * Returns true if the specified address is slashed.
      */
-    function isActiveValidator(address _validator)
+    function isSlashed(address _validator)
         public
         view
         returns(bool)
     {
-        return validators[_validator].status == ValidatorStatus.Staked;
+        return validators[_validator].status == ValidatorStatus.Slashed;
     }
 }

--- a/contracts/reputation/ReputationI.sol
+++ b/contracts/reputation/ReputationI.sol
@@ -16,7 +16,7 @@ pragma solidity ^0.5.0;
 
 interface ReputationI {
 
-    function isActiveValidator(address _validator) external view returns (bool);
+    function isSlashed(address _validator) external view returns (bool);
 
     function join(
         address _validator,

--- a/contracts/reputation/ReputationI.sol
+++ b/contracts/reputation/ReputationI.sol
@@ -24,7 +24,7 @@ interface ReputationI {
     )
         external;
 
-    function logout(address _validator) external;
+    function deregister(address _validator) external;
 
     function getReputation(address _validator) external view returns (uint256);
 }

--- a/contracts/reputation/ReputationI.sol
+++ b/contracts/reputation/ReputationI.sol
@@ -16,7 +16,7 @@ pragma solidity ^0.5.0;
 
 interface ReputationI {
 
-    function isActive(address _validator) external view returns (bool);
+    function isActiveValidator(address _validator) external view returns (bool);
 
     function join(
         address _validator,

--- a/contracts/reputation/ReputationI.sol
+++ b/contracts/reputation/ReputationI.sol
@@ -18,7 +18,7 @@ interface ReputationI {
 
     function isSlashed(address _validator) external view returns (bool);
 
-    function join(
+    function stake(
         address _validator,
         address _withdrawalAddress
     )

--- a/contracts/test/consensus/MockConsensus.sol
+++ b/contracts/test/consensus/MockConsensus.sol
@@ -95,10 +95,16 @@ contract MockConsensus is ConsensusI, ReputationI {
         mockCore.logout(_validator);
     }
 
+    function stake(address _validator, address _withdrawalAddress)
+        external
+    {
+
+    }
+
     function deregister(address _validator)
         external
     {
-        rep[_validator] = uint256(0);
+
     }
 
     function removeVote(address _validator)

--- a/contracts/test/consensus/MockConsensus.sol
+++ b/contracts/test/consensus/MockConsensus.sol
@@ -88,11 +88,17 @@ contract MockConsensus is ConsensusI, ReputationI {
         mockCore.join(_validator);
     }
 
-    function deregister(address _validator)
+    function logout(address _validator)
         external
     {
         rep[_validator] = uint256(0);
         mockCore.logout(_validator);
+    }
+
+    function deregister(address _validator)
+        external
+    {
+        rep[_validator] = uint256(0);
     }
 
     function removeVote(address _validator)

--- a/contracts/test/consensus/MockConsensus.sol
+++ b/contracts/test/consensus/MockConsensus.sol
@@ -101,8 +101,8 @@ contract MockConsensus is ConsensusI, ReputationI {
         mockCore.removeVote(_validator);
     }
 
-    function isActive(address _validator)
-        external
+    function isActiveValidator(address _validator)
+        public
         view
         returns (bool)
     {

--- a/contracts/test/consensus/MockConsensus.sol
+++ b/contracts/test/consensus/MockConsensus.sol
@@ -101,12 +101,12 @@ contract MockConsensus is ConsensusI, ReputationI {
         mockCore.removeVote(_validator);
     }
 
-    function isActiveValidator(address _validator)
+    function isSlashed(address _validator)
         public
         view
         returns (bool)
     {
-        return (rep[_validator] > 0);
+        return (rep[_validator] == 0);
     }
 
     function getReputation(address _validator)

--- a/contracts/test/consensus/MockConsensus.sol
+++ b/contracts/test/consensus/MockConsensus.sol
@@ -88,7 +88,7 @@ contract MockConsensus is ConsensusI, ReputationI {
         mockCore.join(_validator);
     }
 
-    function logout(address _validator)
+    function deregister(address _validator)
         external
     {
         rep[_validator] = uint256(0);

--- a/contracts/test/consensus/MockConsensus.sol
+++ b/contracts/test/consensus/MockConsensus.sol
@@ -98,13 +98,13 @@ contract MockConsensus is ConsensusI, ReputationI {
     function stake(address _validator, address _withdrawalAddress)
         external
     {
-
+        // do nothing for now
     }
 
     function deregister(address _validator)
         external
     {
-
+        // do nothing for now
     }
 
     function removeVote(address _validator)

--- a/contracts/test/reputation/SpyReputation.sol
+++ b/contracts/test/reputation/SpyReputation.sol
@@ -81,7 +81,7 @@ contract SpyReputation is MasterCopyNonUpgradable, ReputationI {
         return reservedStorageSlotForProxy;
     }
 
-    function join(
+    function stake(
         address _validator,
         address _withdrawalAddress
     )

--- a/contracts/test/reputation/SpyReputation.sol
+++ b/contracts/test/reputation/SpyReputation.sol
@@ -91,7 +91,7 @@ contract SpyReputation is MasterCopyNonUpgradable, ReputationI {
         spyWithdrawalAddress = _withdrawalAddress;
     }
 
-    function logout(address _validator) external {
+    function deregister(address _validator) external {
         validator = _validator;
     }
 

--- a/contracts/test/reputation/SpyReputation.sol
+++ b/contracts/test/reputation/SpyReputation.sol
@@ -45,10 +45,10 @@ contract SpyReputation is MasterCopyNonUpgradable, ReputationI {
         activeValidators[_validator] = _active;
     }
 
-    function isActive(
+    function isActiveValidator(
         address _validator
     )
-        external
+        public
         view
         returns (bool)
     {

--- a/contracts/test/reputation/SpyReputation.sol
+++ b/contracts/test/reputation/SpyReputation.sol
@@ -45,14 +45,14 @@ contract SpyReputation is MasterCopyNonUpgradable, ReputationI {
         activeValidators[_validator] = _active;
     }
 
-    function isActiveValidator(
+    function isSlashed(
         address _validator
     )
         public
         view
         returns (bool)
     {
-        return activeValidators[_validator];
+        return !activeValidators[_validator];
     }
 
     function setup(

--- a/test/consensus/enter_committee.js
+++ b/test/consensus/enter_committee.js
@@ -60,7 +60,7 @@ contract('Consensus::enterCommittee', (accounts) => {
       await reputation.setIsActive(validator, false);
       await Utils.expectRevert(
         consensus.enterCommittee(committee.address, validator, furtherMember),
-        'Validator is not active.',
+        'Validator is slashed.',
       );
     });
 

--- a/test/core/register_vote.js
+++ b/test/core/register_vote.js
@@ -254,7 +254,7 @@ contract('Core::registerVote', (accounts) => {
           config.validator0.proposalSignature.s,
           config.validator0.proposalSignature.v,
         ),
-        'Validator must be active.',
+        'Validator is slashed.',
       );
     });
 

--- a/test/reputation/cashout_earnings.js
+++ b/test/reputation/cashout_earnings.js
@@ -114,7 +114,7 @@ contract('Reputation::cashoutEarnings', (accounts) => {
   it('should allow cashout of earnings for logged out validator', async () => {
     const amount = 499;
 
-    await reputation.logout(validator.address, { from: constructorArgs.consensus });
+    await reputation.deregister(validator.address, { from: constructorArgs.consensus });
 
     const response = await reputation.cashOutEarnings(
       amount,
@@ -168,7 +168,7 @@ contract('Reputation::cashoutEarnings', (accounts) => {
   it('should fail for withdrawn validator', async () => {
     const amount = 499;
 
-    await reputation.logout(validator.address, { from: constructorArgs.consensus });
+    await reputation.deregister(validator.address, { from: constructorArgs.consensus });
     await Utils.advanceBlocks(constructorArgs.withdrawalCooldownPeriodInBlocks + 1);
     await reputation.withdraw(
       validator.address,

--- a/test/reputation/cashout_earnings.js
+++ b/test/reputation/cashout_earnings.js
@@ -80,7 +80,7 @@ contract('Reputation::cashoutEarnings', (accounts) => {
       { from: validator.address },
     );
 
-    await reputation.join(
+    await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
@@ -147,7 +147,7 @@ contract('Reputation::cashoutEarnings', (accounts) => {
       amount,
       { from: unknownValidator },
     ),
-    'Validator has not joined.');
+    'Validator has not staked.');
   });
 
   it('should fail for slashed validator', async () => {

--- a/test/reputation/decrease_reputation.js
+++ b/test/reputation/decrease_reputation.js
@@ -72,7 +72,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
       { from: validator.address },
     );
 
-    await reputation.join(
+    await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },

--- a/test/reputation/decrease_reputation.js
+++ b/test/reputation/decrease_reputation.js
@@ -156,7 +156,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
   });
 
   it('should fail for logged out validator', async () => {
-    await reputation.logout(validator.address, { from: constructorArgs.consensus });
+    await reputation.deregister(validator.address, { from: constructorArgs.consensus });
     const delta = 100;
 
     await Utils.expectRevert(reputation.decreaseReputation(
@@ -168,7 +168,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
   });
 
   it('should fail for withdraw-ed validator', async () => {
-    await reputation.logout(validator.address, { from: constructorArgs.consensus });
+    await reputation.deregister(validator.address, { from: constructorArgs.consensus });
     await Utils.advanceBlocks(constructorArgs.withdrawalCooldownPeriodInBlocks + 1);
     await reputation.withdraw(validator.address, { from: constructorArgs.consensus });
 

--- a/test/reputation/deposit_earnings.js
+++ b/test/reputation/deposit_earnings.js
@@ -174,7 +174,7 @@ contract('Reputation::depositEarnings', (accounts) => {
   it('should fail for logged out validator', async () => {
     const amount = 1000;
 
-    await reputation.logout(validator.address, { from: constructorArgs.consensus });
+    await reputation.deregister(validator.address, { from: constructorArgs.consensus });
 
     await Utils.expectRevert(reputation.depositEarnings(
       validator.address,
@@ -187,7 +187,7 @@ contract('Reputation::depositEarnings', (accounts) => {
   it('should fail for withdrawn validator', async () => {
     const amount = 1000;
 
-    await reputation.logout(validator.address, { from: constructorArgs.consensus });
+    await reputation.deregister(validator.address, { from: constructorArgs.consensus });
 
     await Utils.advanceBlocks(constructorArgs.withdrawalCooldownPeriodInBlocks + 1);
 

--- a/test/reputation/deposit_earnings.js
+++ b/test/reputation/deposit_earnings.js
@@ -80,7 +80,7 @@ contract('Reputation::depositEarnings', (accounts) => {
       { from: validator.address },
     );
 
-    await reputation.join(
+    await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },

--- a/test/reputation/deregister.js
+++ b/test/reputation/deregister.js
@@ -21,7 +21,7 @@ const Utils = require('../test_lib/utils.js');
 const Reputation = artifacts.require('Reputation');
 const MockToken = artifacts.require('MockToken');
 
-contract('Reputation::logout', (accounts) => {
+contract('Reputation::deregister', (accounts) => {
   let constructorArgs;
   let validator;
   let accountProvider;
@@ -80,8 +80,8 @@ contract('Reputation::logout', (accounts) => {
     );
   });
 
-  it('should be able to logout', async () => {
-    const response = await reputation.logout(
+  it('should be able to deregister', async () => {
+    const response = await reputation.deregister(
       validator.address,
       { from: constructorArgs.consensus },
     );
@@ -94,8 +94,8 @@ contract('Reputation::logout', (accounts) => {
     const validatorObject = await reputation.validators.call(validator.address);
 
     assert.isOk(
-      validatorObject.status.eqn(ValidatorStatus.LoggedOut),
-      `Expected status is ${ValidatorStatus.LoggedOut} but found ${validatorObject.status}`,
+      validatorObject.status.eqn(ValidatorStatus.DeRegistered),
+      `Expected status is ${ValidatorStatus.DeRegistered} but found ${validatorObject.status}`,
     );
     const expectedWithdrawalBlockHeight = response.receipt.blockNumber
       + constructorArgs.withdrawalCooldownPeriodInBlocks;
@@ -109,7 +109,7 @@ contract('Reputation::logout', (accounts) => {
   it('should fail for unknown validator', async () => {
     const unknownValidator = accountProvider.get();
 
-    await Utils.expectRevert(reputation.logout(
+    await Utils.expectRevert(reputation.deregister(
       unknownValidator,
       { from: constructorArgs.consensus },
     ),
@@ -119,17 +119,17 @@ contract('Reputation::logout', (accounts) => {
   it('should fail if transaction is done by account other than consensus', async () => {
     const otherAccount = accountProvider.get();
 
-    await Utils.expectRevert(reputation.logout(
+    await Utils.expectRevert(reputation.deregister(
       validator.address,
       { from: otherAccount },
     ),
     'Only the consensus contract can call this function.');
   });
 
-  it('should fail for logged out validator', async () => {
-    await reputation.logout(validator.address, { from: constructorArgs.consensus });
+  it('should fail for deregistered validator', async () => {
+    await reputation.deregister(validator.address, { from: constructorArgs.consensus });
 
-    await Utils.expectRevert(reputation.logout(
+    await Utils.expectRevert(reputation.deregister(
       validator.address,
       { from: constructorArgs.consensus },
     ),
@@ -137,11 +137,11 @@ contract('Reputation::logout', (accounts) => {
   });
 
   it('should fail for withdraw-ed validator', async () => {
-    await reputation.logout(validator.address, { from: constructorArgs.consensus });
+    await reputation.deregister(validator.address, { from: constructorArgs.consensus });
     await Utils.advanceBlocks(constructorArgs.withdrawalCooldownPeriodInBlocks + 1);
     await reputation.withdraw(validator.address, { from: constructorArgs.consensus });
 
-    await Utils.expectRevert(reputation.logout(
+    await Utils.expectRevert(reputation.deregister(
       validator.address,
       { from: constructorArgs.consensus },
     ),
@@ -151,7 +151,7 @@ contract('Reputation::logout', (accounts) => {
   it('should fail for slashed validator', async () => {
     await reputation.slash(validator.address, { from: constructorArgs.consensus });
 
-    await Utils.expectRevert(reputation.logout(
+    await Utils.expectRevert(reputation.deregister(
       validator.address,
       { from: constructorArgs.consensus },
     ),

--- a/test/reputation/deregister.js
+++ b/test/reputation/deregister.js
@@ -94,8 +94,8 @@ contract('Reputation::deregister', (accounts) => {
     const validatorObject = await reputation.validators.call(validator.address);
 
     assert.isOk(
-      validatorObject.status.eqn(ValidatorStatus.DeRegistered),
-      `Expected status is ${ValidatorStatus.DeRegistered} but found ${validatorObject.status}`,
+      validatorObject.status.eqn(ValidatorStatus.Deregistered),
+      `Expected status is ${ValidatorStatus.Deregistered} but found ${validatorObject.status}`,
     );
     const expectedWithdrawalBlockHeight = response.receipt.blockNumber
       + constructorArgs.withdrawalCooldownPeriodInBlocks;

--- a/test/reputation/deregister.js
+++ b/test/reputation/deregister.js
@@ -73,7 +73,7 @@ contract('Reputation::deregister', (accounts) => {
       { from: validator.address },
     );
 
-    await reputation.join(
+    await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },

--- a/test/reputation/deregister.js
+++ b/test/reputation/deregister.js
@@ -113,7 +113,7 @@ contract('Reputation::deregister', (accounts) => {
       unknownValidator,
       { from: constructorArgs.consensus },
     ),
-    'Validator is slashed.');
+    'Validator is not active.');
   });
 
   it('should fail if transaction is done by account other than consensus', async () => {

--- a/test/reputation/get_reputation.js
+++ b/test/reputation/get_reputation.js
@@ -73,7 +73,7 @@ contract('Reputation::getReputation', (accounts) => {
       { from: validator.address },
     );
 
-    await reputation.join(
+    await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },

--- a/test/reputation/increase_reputation.js
+++ b/test/reputation/increase_reputation.js
@@ -72,7 +72,7 @@ contract('Reputation::increaseReputation', (accounts) => {
       { from: validator.address },
     );
 
-    await reputation.join(
+    await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },

--- a/test/reputation/increase_reputation.js
+++ b/test/reputation/increase_reputation.js
@@ -138,7 +138,7 @@ contract('Reputation::increaseReputation', (accounts) => {
   });
 
   it('should fail for logged out validator', async () => {
-    await reputation.logout(validator.address, { from: constructorArgs.consensus });
+    await reputation.deregister(validator.address, { from: constructorArgs.consensus });
     const delta = 100;
 
     await Utils.expectRevert(reputation.increaseReputation(
@@ -150,7 +150,7 @@ contract('Reputation::increaseReputation', (accounts) => {
   });
 
   it('should fail for withdraw-ed validator', async () => {
-    await reputation.logout(validator.address, { from: constructorArgs.consensus });
+    await reputation.deregister(validator.address, { from: constructorArgs.consensus });
     await Utils.advanceBlocks(constructorArgs.withdrawalCooldownPeriodInBlocks + 1);
     await reputation.withdraw(validator.address, { from: constructorArgs.consensus });
 

--- a/test/reputation/logout.js
+++ b/test/reputation/logout.js
@@ -113,7 +113,7 @@ contract('Reputation::logout', (accounts) => {
       unknownValidator,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+    'Validator is slashed.');
   });
 
   it('should fail if transaction is done by account other than consensus', async () => {

--- a/test/reputation/setup.js
+++ b/test/reputation/setup.js
@@ -160,7 +160,7 @@ contract('Reputation::setup', (accounts) => {
         constructorArgs.initialReputation,
         constructorArgs.withdrawalCooldownPeriodInBlocks,
       ),
-      'Stake amount to join in mOST is not positive.',
+      'Stake amount in mOST is not positive.',
     );
   });
 
@@ -196,7 +196,7 @@ contract('Reputation::setup', (accounts) => {
         constructorArgs.initialReputation,
         constructorArgs.withdrawalCooldownPeriodInBlocks,
       ),
-      'Stake amount to join in wETH is not positive.',
+      'Stake amount in wETH is not positive.',
     );
   });
 

--- a/test/reputation/slash.js
+++ b/test/reputation/slash.js
@@ -136,7 +136,7 @@ contract('Reputation::slash', (accounts) => {
 
 
   it('should fail if validator has already withdrawn', async () => {
-    await reputation.logout(validator.address, { from: constructorArgs.consensus });
+    await reputation.deregister(validator.address, { from: constructorArgs.consensus });
     await Utils.advanceBlocks(constructorArgs.withdrawalCooldownPeriodInBlocks + 1);
     await reputation.withdraw(validator.address, { from: constructorArgs.consensus });
 

--- a/test/reputation/slash.js
+++ b/test/reputation/slash.js
@@ -73,7 +73,7 @@ contract('Reputation::slash', (accounts) => {
       { from: validator.address },
     );
 
-    await reputation.join(
+    await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
@@ -131,7 +131,7 @@ contract('Reputation::slash', (accounts) => {
       otherAccount,
       { from: constructorArgs.consensus },
     ),
-    'Validator has not joined.');
+    'Validator has not staked.');
   });
 
 

--- a/test/reputation/stake.js
+++ b/test/reputation/stake.js
@@ -23,7 +23,7 @@ const Utils = require('../test_lib/utils.js');
 const Reputation = artifacts.require('Reputation');
 const MockToken = artifacts.require('MockToken');
 
-contract('Reputation::join', (accounts) => {
+contract('Reputation::stake', (accounts) => {
   let constructorArgs;
   let validator;
   let accountProvider;
@@ -77,8 +77,8 @@ contract('Reputation::join', (accounts) => {
     );
   });
 
-  it('should be able to join validator pool', async () => {
-    const response = await reputation.join(
+  it('should be able to stake in validator pool', async () => {
+    const response = await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
@@ -91,7 +91,7 @@ contract('Reputation::join', (accounts) => {
   });
 
   it('should create storage for validator', async () => {
-    const response = await reputation.join(
+    const response = await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
@@ -140,7 +140,7 @@ contract('Reputation::join', (accounts) => {
   });
 
   it('should increase reputation contract balance', async () => {
-    await reputation.join(
+    await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
@@ -160,17 +160,17 @@ contract('Reputation::join', (accounts) => {
     );
   });
 
-  it('should fail in non consensus address tries to join a validator', async () => {
+  it('should fail in non consensus address tries to stake a validator', async () => {
     const nonConsensusAddress = accountProvider.get();
 
-    await Utils.expectRevert(reputation.join(
+    await Utils.expectRevert(reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: nonConsensusAddress },
     ),
     'Only the consensus contract can call this function.');
   });
-  it('should fail to join validator pool if mOST token is not approved', async () => {
+  it('should fail to stake validator pool if mOST token is not approved', async () => {
     await mOST.approve(
       reputation.address,
       '0',
@@ -179,14 +179,14 @@ contract('Reputation::join', (accounts) => {
 
     // Can't assert message, because transferFrom will revert/throw as per the specification.
     // https://eips.ethereum.org/EIPS/eip-20
-    await Utils.expectRevert(reputation.join(
+    await Utils.expectRevert(reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
     ));
   });
 
-  it('should fail to join validator pool if eETH token is not approved', async () => {
+  it('should fail to stake validator pool if eETH token is not approved', async () => {
     await wETH.approve(
       reputation.address,
       '0',
@@ -195,7 +195,7 @@ contract('Reputation::join', (accounts) => {
 
     // Can't assert message, because transferFrom will revert/throw as per the specification.
     // https://eips.ethereum.org/EIPS/eip-20
-    await Utils.expectRevert(reputation.join(
+    await Utils.expectRevert(reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
@@ -203,7 +203,7 @@ contract('Reputation::join', (accounts) => {
   });
 
   it('should fail for zero validator address', async () => {
-    await Utils.expectRevert(reputation.join(
+    await Utils.expectRevert(reputation.stake(
       NULL_ADDRESS,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
@@ -212,7 +212,7 @@ contract('Reputation::join', (accounts) => {
   });
 
   it('should fail for zero withdrawal address', async () => {
-    await Utils.expectRevert(reputation.join(
+    await Utils.expectRevert(reputation.stake(
       validator.address,
       NULL_ADDRESS,
       { from: constructorArgs.consensus },
@@ -221,7 +221,7 @@ contract('Reputation::join', (accounts) => {
   });
 
   it('should fail if validator address is same as withdrawal address', async () => {
-    await Utils.expectRevert(reputation.join(
+    await Utils.expectRevert(reputation.stake(
       validator.address,
       validator.address,
       { from: constructorArgs.consensus },
@@ -229,22 +229,22 @@ contract('Reputation::join', (accounts) => {
     'Validator\'s address is the same as its withdrawal address.');
   });
 
-  it('should fail if validator has already joined', async () => {
-    await reputation.join(
+  it('should fail if validator has already staked', async () => {
+    await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
     );
 
-    await Utils.expectRevert(reputation.join(
+    await Utils.expectRevert(reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
     ),
-    'No validator can rejoin.');
+    'No validator can stake again.');
   });
 
-  it('should fail if withdrawal address has already joined as validator', async () => {
+  it('should fail if withdrawal address has already staked as validator', async () => {
     await mOST.transfer(
       validator.withdrawalAddress,
       constructorArgs.stakeMOSTAmount,
@@ -267,12 +267,12 @@ contract('Reputation::join', (accounts) => {
       constructorArgs.stakeWETHAmount,
       { from: validator.withdrawalAddress },
     );
-    await reputation.join(
+    await reputation.stake(
       validator.withdrawalAddress,
       validator.address,
       { from: constructorArgs.consensus },
     );
-    await Utils.expectRevert(reputation.join(
+    await Utils.expectRevert(reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },

--- a/test/reputation/utils.js
+++ b/test/reputation/utils.js
@@ -19,7 +19,7 @@ module.exports = {
     Undefined: 0,
     Slashed: 1,
     Staked: 2,
-    DeRegistered: 3,
+    Deregistered: 3,
     Withdrawn: 4,
   },
 };

--- a/test/reputation/utils.js
+++ b/test/reputation/utils.js
@@ -19,7 +19,7 @@ module.exports = {
     Undefined: 0,
     Slashed: 1,
     Staked: 2,
-    LoggedOut: 3,
+    DeRegistered: 3,
     Withdrawn: 4,
   },
 };

--- a/test/reputation/withdraw.js
+++ b/test/reputation/withdraw.js
@@ -74,7 +74,7 @@ contract('Reputation::withdraw', (accounts) => {
       { from: validator.address },
     );
 
-    await reputation.join(
+    await reputation.stake(
       validator.address,
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },

--- a/test/reputation/withdraw.js
+++ b/test/reputation/withdraw.js
@@ -82,7 +82,7 @@ contract('Reputation::withdraw', (accounts) => {
   });
 
   it('should be able to withdraw after cool down period', async () => {
-    await reputation.logout(
+    await reputation.deregister(
       validator.address,
       { from: constructorArgs.consensus },
     );
@@ -113,7 +113,7 @@ contract('Reputation::withdraw', (accounts) => {
     await mOST.approve(reputation.address, validatorEarnings, { from: validator.address });
     await reputation.depositEarnings(validator.address, validatorEarnings);
 
-    await reputation.logout(
+    await reputation.deregister(
       validator.address,
       { from: constructorArgs.consensus },
     );
@@ -150,7 +150,7 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator has not logged out.');
+    'Validator has not deregistered.');
   });
 
   it('should fail to withdraw if validator is not logged out', async () => {
@@ -158,11 +158,11 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator has not logged out.');
+    'Validator has not deregistered.');
   });
 
   it('should fail to withdraw if validator is slashed', async () => {
-    await reputation.logout(
+    await reputation.deregister(
       validator.address,
       { from: constructorArgs.consensus },
     );
@@ -176,11 +176,11 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator has not logged out.');
+    'Validator has not deregistered.');
   });
 
   it('should fail to withdraw if cool down period has not elapsed', async () => {
-    await reputation.logout(
+    await reputation.deregister(
       validator.address,
       { from: constructorArgs.consensus },
     );
@@ -193,7 +193,7 @@ contract('Reputation::withdraw', (accounts) => {
   });
 
   it('should fail if validator is already withdrawn', async () => {
-    await reputation.logout(
+    await reputation.deregister(
       validator.address,
       { from: constructorArgs.consensus },
     );


### PR DESCRIPTION
- Introduce new interface `isSlashed` in reputation contract with below function signature:
```
function isSlashed(address _validator)
        public
        view
        returns(bool)
    {}
```
Remove interface isActive from Reputation contract. Keep the isActive modifier as it is.
Core.registerVote should call this method.
Consensus.enterCommittee should call this method.

- Even after user gets logged out in Reputation contract, he is accountable for his vote. 
   - Rename `Reputation.logout` to `Reputation.deregister` 
   - Update status `LoggedOut` to `DeRegistered` 


- Rename method `Reputation.join` to `Reputation.stake`

Fixes #64 