### PR TITLE
Consensus::newCore refactoring

### DIFF
--- a/contracts/axiom/Axiom.sol
+++ b/contracts/axiom/Axiom.sol
@@ -271,8 +271,6 @@ contract Axiom is AxiomI, ProxyFactory, ConsensusModule {
             "Consensus must be setup."
         );
 
-        bytes32 source = keccak256(_rootRlpBlockHeader);
-
         Block.Header memory blockHeader = Block.decodeHeader(_rootRlpBlockHeader);
 
         // Task: When new Anchor is implemented, use proxy pattern for deployment.
@@ -286,7 +284,6 @@ contract Axiom is AxiomI, ProxyFactory, ConsensusModule {
         consensus.newMetaChain(
             address(anchor),
             EPOCH_LENGTH,
-            source,
             blockHeader.height
         );
     }

--- a/contracts/consensus/Consensus.sol
+++ b/contracts/consensus/Consensus.sol
@@ -53,7 +53,7 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
     /** The callprefix of the Core::setup function. */
     bytes4 public constant CORE_SETUP_CALLPREFIX = bytes4(
         keccak256(
-            "setup(address,bytes20,uint256,uint256,uint256,address,uint256,bytes32,uint256,uint256,uint256,bytes32,uint256)"
+            "setup(address,bytes20,uint256,uint256,uint256,address,uint256,bytes32,uint256,uint256,uint256,uint256)"
         )
     );
 
@@ -604,13 +604,11 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
      *
      * @param _anchor anchor of the new meta-chain.
      * @param _epochLength Epoch length for new meta-chain.
-     * @param _rootBlockHash root block hash.
      * @param _rootBlockHeight root block height.
      */
     function newMetaChain(
         address _anchor,
         uint256 _epochLength,
-        bytes32 _rootBlockHash,
         uint256 _rootBlockHeight
     )
         external
@@ -631,7 +629,6 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
             gasTargetDelta, // gas target
             uint256(0), // dynasty
             uint256(0), // accumulated gas
-            _rootBlockHash,
             _rootBlockHeight
         );
 
@@ -798,7 +795,6 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
      * @param _gasTarget Gas target to close the meta block.
      * @param _dynasty Committed dynasty number.
      * @param _accumulatedGas Accumulated gas.
-     * @param _source Source block hash
      * @param _sourceBlockHeight Source block height.
      * returns Deployed core contract address.
      */
@@ -810,7 +806,6 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
         uint256 _gasTarget,
         uint256 _dynasty,
         uint256 _accumulatedGas,
-        bytes32 _source,
         uint256 _sourceBlockHeight
     )
         private
@@ -829,7 +824,6 @@ contract Consensus is MasterCopyNonUpgradable, CoreStatusEnum, ConsensusI {
             _gasTarget,
             _dynasty,
             _accumulatedGas,
-            _source,
             _sourceBlockHeight
         );
 

--- a/contracts/consensus/ConsensusI.sol
+++ b/contracts/consensus/ConsensusI.sol
@@ -48,13 +48,11 @@ interface ConsensusI {
      *
      * @param _anchor Anchor address of the new meta-chain.
      * @param _epochLength Epoch length for the new meta-chain.
-     * @param _rootBlockHash Root block hash.
      * @param _rootBlockHeight Root block height.
      */
     function newMetaChain(
         address _anchor,
         uint256 _epochLength,
-        bytes32 _rootBlockHash,
         uint256 _rootBlockHeight
     )
         external;

--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -192,9 +192,6 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
     /** Committed dynasty number */
     uint256 public committedDynasty;
 
-    /** Committed source block hash */
-    bytes32 public committedSource;
-
     /** Committed sourceBlockHeight */
     uint256 public committedSourceBlockHeight;
 
@@ -283,7 +280,6 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
         uint256 _gasTarget,
         uint256 _dynasty,
         uint256 _accumulatedGas,
-        bytes32 _source,
         uint256 _sourceBlockHeight
     )
         external
@@ -329,11 +325,6 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
             "Metablock's accumulated gas is 0."
         );
 
-        require(
-            _source != bytes32(0),
-            "Metablock's source is 0."
-        );
-
         domainSeparator = keccak256(
             abi.encode(
                 DOMAIN_SEPARATOR_TYPEHASH,
@@ -364,7 +355,6 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
 
         committedDynasty = _dynasty;
         committedAccumulatedGas = _accumulatedGas;
-        committedSource = _source;
         committedSourceBlockHeight = _sourceBlockHeight;
     }
 
@@ -388,8 +378,6 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
      *          - source block height is strictly greater than committed
      *            block height
      *          - source block height is a checkpoint
-     *          - source block hash does not match with the committed source
-     *            block hash
      *          - target block height is +1 epoch of the source block height
      *          - a proposal matching with the input parameters does
      *            not exist in the core
@@ -451,10 +439,6 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
         require(
             _target != bytes32(0),
             "Target blockhash must not be null."
-        );
-        require(
-            _source != committedSource,
-            "Source blockhash cannot equal sealed source blockhash."
         );
         require(
             _sourceBlockHeight > committedSourceBlockHeight,
@@ -682,7 +666,6 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
 
         committedDynasty = _committedDynasty;
         committedAccumulatedGas = _committedAccumulatedGas;
-        committedSource = _committedSource;
         committedSourceBlockHeight = _committedSourceBlockHeight;
 
         uint256 nextKernelHeight = openKernelHeight.add(1);

--- a/contracts/test/axiom/SpyAxiom.sol
+++ b/contracts/test/axiom/SpyAxiom.sol
@@ -46,7 +46,6 @@ contract SpyAxiom is AxiomI{
         Consensus _consensus,
         bytes20 _chainId,
         uint256 _epochLength,
-        bytes32 _source,
         uint256 _sourceBlockHeight
     )
         external
@@ -55,7 +54,6 @@ contract SpyAxiom is AxiomI{
             // TODO: align unit tests
             address(_chainId),
             _epochLength,
-            _source,
             _sourceBlockHeight
         );
     }

--- a/contracts/test/consensus/MockConsensus.sol
+++ b/contracts/test/consensus/MockConsensus.sol
@@ -45,7 +45,6 @@ contract MockConsensus is ConsensusI, ReputationI {
         uint256 _gasTarget,
         uint256 _dynasty,
         uint256 _accumulatedGas,
-        bytes32 _source,
         uint256 _sourceBlockHeight
     )
         public
@@ -66,7 +65,6 @@ contract MockConsensus is ConsensusI, ReputationI {
             _gasTarget,
             _dynasty,
             _accumulatedGas,
-            _source,
             _sourceBlockHeight
         );
     }
@@ -149,7 +147,6 @@ contract MockConsensus is ConsensusI, ReputationI {
     function newMetaChain(
         address _anchor,
         uint256 _epochLength,
-        bytes32 _source,
         uint256 _sourceBlockHeight
     )
         external

--- a/contracts/test/consensus/SpyConsensus.sol
+++ b/contracts/test/consensus/SpyConsensus.sol
@@ -15,7 +15,6 @@ contract SpyConsensus is MasterCopyNonUpgradable, ConsensusI {
 
     address public anchor;
     uint256 public epochLength;
-    bytes32 public source;
     uint256 public sourceBlockHeight;
 
     address public deployedContractAddress;
@@ -45,14 +44,12 @@ contract SpyConsensus is MasterCopyNonUpgradable, ConsensusI {
     function newMetaChain(
         address _anchor,
         uint256 _epochLength,
-        bytes32 _source,
         uint256 _sourceBlockHeight
     )
         external
     {
         anchor = _anchor;
         epochLength = _epochLength;
-        source = _source;
         sourceBlockHeight = _sourceBlockHeight;
     }
 

--- a/contracts/test/core/SpyCore.sol
+++ b/contracts/test/core/SpyCore.sol
@@ -19,7 +19,6 @@ contract SpyCore is MasterCopyNonUpgradable, CoreI{
     uint256 public spyGasTarget;
     uint256 public spyDynasty;
     uint256 public spyAccumulatedGas;
-    bytes32 public spySource;
     uint256 public spySourceBlockHeight;
 
     address public spyValidator;
@@ -46,7 +45,6 @@ contract SpyCore is MasterCopyNonUpgradable, CoreI{
         uint256 _gasTarget,
         uint256 _dynasty,
         uint256 _accumulatedGas,
-        bytes32 _source,
         uint256 _sourceBlockHeight
     )
         external
@@ -63,7 +61,6 @@ contract SpyCore is MasterCopyNonUpgradable, CoreI{
         spyGasTarget = _gasTarget;
         spyDynasty = _dynasty;
         spyAccumulatedGas = _accumulatedGas;
-        spySource = _source;
         spySourceBlockHeight = _sourceBlockHeight;
     }
     function joinDuringCreation(address _validator) external {

--- a/test/axiom/new_core.js
+++ b/test/axiom/new_core.js
@@ -94,7 +94,6 @@ contract('Axiom::newCore', (accounts) => {
       gasTarget: new BN(Utils.getRandomNumber(999999)),
       dynasty: new BN(Utils.getRandomNumber(10)),
       accumulatedGas: new BN(Utils.getRandomNumber(999999)),
-      source: Utils.getRandomHash(),
       sourceBlockHeight: new BN(Utils.getRandomNumber(1000)),
     };
     Object.freeze(newCoreParams);
@@ -240,13 +239,6 @@ contract('Axiom::newCore', (accounts) => {
         spyAccumulatedGas.eq(newCoreParams.accumulatedGas),
         true,
         'Accumulated gas value in spy core contract is not set.',
-      );
-
-      const spySource = await spyCore.spySource.call();
-      assert.strictEqual(
-        spySource,
-        newCoreParams.source,
-        'Source value in spy core contract is not set.',
       );
 
       const spySourceBlockHeight = await spyCore.spySourceBlockHeight.call();

--- a/test/axiom/new_meta_chain.js
+++ b/test/axiom/new_meta_chain.js
@@ -112,8 +112,6 @@ contract('Axiom::newMetaChain', (accounts) => {
     });
 
     it('should validate the spied values of the consensus proxy contract', async () => {
-      const blockHash = web3.utils.sha3(newMetaChainParams.rlpBlockHeader);
-
       await AxiomUtils.newMetaChainWithConfig(axiom, newMetaChainParams);
 
       const consensusContractAddress = await axiom.consensus.call();
@@ -124,13 +122,6 @@ contract('Axiom::newMetaChain', (accounts) => {
         epochLength.eqn(EPOCH_LENGTH),
         true,
         'Epoch length value is not set in the contract.',
-      );
-
-      const source = await consensusProxyContract.source.call();
-      assert.strictEqual(
-        source,
-        blockHash,
-        'Source value is not set in the contract.',
       );
 
       const sourceBlockHeight = await consensusProxyContract.sourceBlockHeight.call();

--- a/test/axiom/utils.js
+++ b/test/axiom/utils.js
@@ -19,7 +19,7 @@ const Utils = require('../test_lib/utils.js');
 
 const ConsensusSetupParamTypes = 'uint256,uint256,uint256,uint256,uint256,address';
 const ReputationSetupParamTypes = 'address,address,uint256,address,uint256,uint256,uint256,uint256';
-const CoreSetupParamTypes = 'address,bytes20,uint256,uint256,uint256,address,uint256,bytes32,uint256,uint256,uint256,bytes32,uint256';
+const CoreSetupParamTypes = 'address,bytes20,uint256,uint256,uint256,address,uint256,bytes32,uint256,uint256,uint256,uint256';
 const CommitteeSetupParamTypes = 'address,uint256,bytes32,bytes32';
 
 const ConsensusSetupFunctionSignature = `setup(${ConsensusSetupParamTypes})`;
@@ -104,7 +104,6 @@ async function encodeNewCoreParams(coreParams) {
       coreParams.gasTarget.toString(10),
       coreParams.dynasty.toString(10),
       coreParams.accumulatedGas.toString(10),
-      coreParams.source,
       coreParams.sourceBlockHeight.toString(10),
     ],
 

--- a/test/consensus/new_meta_chain.js
+++ b/test/consensus/new_meta_chain.js
@@ -50,7 +50,6 @@ contract('Consensus::newMetaChain', (accounts) => {
         contracts.Consensus.newMetaChain(
           inputParams.chainId,
           inputParams.epochLength,
-          inputParams.source,
           inputParams.sourceBlockHeight,
           {
             from: accountProvider.get(),
@@ -124,7 +123,6 @@ contract('Consensus::newMetaChain', (accounts) => {
         gasTarget: 99999,
         dynasty: 0,
         accumulatedGas: 0,
-        source: inputParams.source,
         sourceBlockHeight: inputParams.sourceBlockHeight,
       });
 

--- a/test/consensus/utils.js
+++ b/test/consensus/utils.js
@@ -72,7 +72,6 @@ async function callNewMetaChainOnConsensus(spyAxiom, params) {
     params.consensus,
     params.chainId,
     params.epochLength,
-    params.source,
     params.sourceBlockHeight,
   );
 }

--- a/test/core/assert_precommit.js
+++ b/test/core/assert_precommit.js
@@ -83,7 +83,6 @@ contract('Core::assertPrecommit', (accounts) => {
       config.consensusCoreArgs.gasTarget,
       config.consensusCoreArgs.dynasty,
       config.consensusCoreArgs.accumulatedGas,
-      config.consensusCoreArgs.source,
       config.consensusCoreArgs.sourceBlockHeight,
       { from: accountProvider.get() },
     );

--- a/test/core/join.js
+++ b/test/core/join.js
@@ -70,7 +70,6 @@ contract('Core::join', async (accounts) => {
       config.consensusCoreArgs.gasTarget,
       config.consensusCoreArgs.dynasty,
       config.consensusCoreArgs.accumulatedGas,
-      config.consensusCoreArgs.source,
       config.consensusCoreArgs.sourceBlockHeight,
       { from: accountProvider.get() },
     );

--- a/test/core/join_during_creation.js
+++ b/test/core/join_during_creation.js
@@ -79,7 +79,6 @@ contract('Core::joinDuringCreation', async (accounts) => {
       config.gasTarget,
       config.dynasty,
       config.accumulatedGas,
-      config.source,
       config.sourceBlockHeight,
       {
         from: config.deployer,

--- a/test/core/logout.js
+++ b/test/core/logout.js
@@ -70,7 +70,6 @@ contract('Core::logout', async (accounts) => {
       config.consensusCoreArgs.gasTarget,
       config.consensusCoreArgs.dynasty,
       config.consensusCoreArgs.accumulatedGas,
-      config.consensusCoreArgs.source,
       config.consensusCoreArgs.sourceBlockHeight,
       { from: accountProvider.get() },
     );

--- a/test/core/open_metablock.js
+++ b/test/core/open_metablock.js
@@ -154,7 +154,6 @@ contract('Core::openMetablock', (accounts) => {
       config.consensusCoreArgs.gasTarget,
       config.consensusCoreArgs.dynasty,
       config.consensusCoreArgs.accumulatedGas,
-      config.consensusCoreArgs.source,
       config.consensusCoreArgs.sourceBlockHeight,
       { from: accountProvider.get() },
     );
@@ -402,12 +401,6 @@ contract('Core::openMetablock', (accounts) => {
       const committedAccumulatedGas = await config.core.committedAccumulatedGas();
       assert.isOk(
         committedAccumulatedGas.eq(config.proposalArgs.accumulatedGas),
-      );
-
-      const committedSource = await config.core.committedSource();
-      assert.strictEqual(
-        committedSource,
-        config.proposalArgs.source,
       );
 
       const committedSourceBlockHeight = await config.core.committedSourceBlockHeight();

--- a/test/core/propose_metablock.js
+++ b/test/core/propose_metablock.js
@@ -101,7 +101,6 @@ contract('Core::proposeMetablock', async (accounts) => {
       config.gasTarget,
       config.dynasty,
       config.accumulatedGas,
-      config.source,
       config.sourceBlockHeight,
       {
         from: config.deployer,
@@ -216,17 +215,6 @@ contract('Core::proposeMetablock', async (accounts) => {
           proposal,
         ),
         'Source block height must be a checkpoint.',
-      );
-    });
-
-    it('should revert if a source block hash matches with the committed one', async () => {
-      proposal.source = config.source;
-      await Utils.expectRevert(
-        proposeMetaBlock(
-          config.core,
-          proposal,
-        ),
-        'Source blockhash cannot equal sealed source blockhash.',
       );
     });
 

--- a/test/core/register_vote.js
+++ b/test/core/register_vote.js
@@ -96,7 +96,6 @@ contract('Core::registerVote', (accounts) => {
       config.consensusCoreArgs.gasTarget,
       config.consensusCoreArgs.dynasty,
       config.consensusCoreArgs.accumulatedGas,
-      config.consensusCoreArgs.source,
       config.consensusCoreArgs.sourceBlockHeight,
       { from: accountProvider.get() },
     );
@@ -179,7 +178,6 @@ contract('Core::registerVote', (accounts) => {
         config.consensusCoreArgs.gasTarget,
         config.consensusCoreArgs.dynasty,
         config.consensusCoreArgs.accumulatedGas,
-        config.consensusCoreArgs.source,
         config.consensusCoreArgs.sourceBlockHeight,
         { from: accountProvider.get() },
       );

--- a/test/core/remove_vote.js
+++ b/test/core/remove_vote.js
@@ -83,7 +83,6 @@ contract('Core::removeVote', (accounts) => {
       config.consensusCoreArgs.gasTarget,
       config.consensusCoreArgs.dynasty,
       config.consensusCoreArgs.accumulatedGas,
-      config.consensusCoreArgs.source,
       config.consensusCoreArgs.sourceBlockHeight,
       { from: accountProvider.get() },
     );

--- a/test/core/setup.js
+++ b/test/core/setup.js
@@ -38,7 +38,6 @@ async function createCore(args, consensus) {
     args.gasTarget,
     args.dynasty,
     args.accumulatedGas,
-    args.source,
     args.sourceBlockHeight,
     {
       from: consensus,
@@ -143,16 +142,6 @@ contract('Core::constructor', (accounts) => {
         'Metablock\'s accumulated gas is 0.',
       );
     });
-
-    it('should revert as metablock\'s source is 0', async () => {
-      const args = correctArgs;
-      args.source = Utils.ZERO_BYTES32;
-
-      await Utils.expectRevert(
-        createCore(args, config.consensus),
-        'Metablock\'s source is 0.',
-      );
-    });
   });
 
   contract('Positive Tests', async () => {
@@ -229,13 +218,6 @@ contract('Core::constructor', (accounts) => {
         committedAccumulatedGas.cmp(correctArgs.accumulatedGas) === 0,
         `Accumulated gas is set to ${committedAccumulatedGas} `
         + `and is not ${correctArgs.accumulatedGas}`,
-      );
-
-      const committedSource = await core.committedSource();
-      assert.strictEqual(
-        committedSource,
-        correctArgs.source,
-        `Source is set to ${committedSource} and is not ${correctArgs.source}`,
       );
 
       const committedSourceBlockHeight = await core.committedSourceBlockHeight();

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -40,7 +40,6 @@ async function createConsensusCore(
   gasTarget,
   dynasty,
   accumulatedGas,
-  source,
   sourceBlockHeight,
   txOptions = {},
 ) {
@@ -54,7 +53,6 @@ async function createConsensusCore(
     gasTarget,
     dynasty,
     accumulatedGas,
-    source,
     sourceBlockHeight,
     txOptions,
   );
@@ -74,7 +72,6 @@ async function createCore(
   gasTarget,
   dynasty,
   accumulatedGas,
-  source,
   sourceBlockHeight,
   txOptions = {},
 ) {
@@ -91,7 +88,6 @@ async function createCore(
     gasTarget,
     dynasty,
     accumulatedGas,
-    source,
     sourceBlockHeight,
     txOptions,
   );


### PR DESCRIPTION
PR covers below:

- source parameter removed from Consensus::newMetaChain
- source parameter removed from Consensus::newCore
- uint256 _source parameter is removed from Core::setup
- CORE_SETUP_CALLPREFIX is updated to exclude _source
- committedSource variable is removed from the Core contract

Fixes #82 