### PR TITLE
Added rootOriginObservationBlockheight storage in Core contract

### DIFF
--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -216,7 +216,10 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
     /** Precommitment closure block height */
     uint256 public precommitClosureBlockHeight;
 
-    /** Origin chain observation blockheight. */
+    /**
+     * Block number at which core status is changed to creation.
+     * It will be used by validators to create GenesisFile.
+     */
     uint256 public rootOriginObservationBlockHeight;
 
 

--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -216,6 +216,9 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
     /** Precommitment closure block height */
     uint256 public precommitClosureBlockHeight;
 
+    /** Origin chain observation blockheight. */
+    uint256 public rootOriginObservationBlockHeight;
+
 
     /* Modifiers */
 
@@ -342,6 +345,7 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
         joinLimit = _joinLimit;
 
         creationKernelHeight = _height;
+        openKernelHeight = _height;
 
         Kernel storage creationKernel = kernels[_height];
         creationKernel.parent = _parent;
@@ -709,7 +713,6 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
         if (countValidators >= minimumValidatorCount) {
             quorum = calculateQuorum(countValidators);
             precommitClosureBlockHeight = CORE_OPEN_VOTES_WINDOW;
-            openKernelHeight = creationKernelHeight;
             openKernelHash = hashKernel(
                 creationKernelHeight,
                 creationKernel.parent,
@@ -718,6 +721,9 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
                 creationKernel.gasTarget
             );
             coreStatus = CoreStatus.opened;
+            // Core status would be changed to `opened`.
+            // So `rootOriginObservationBlockHeight` would be set once.
+            rootOriginObservationBlockHeight = block.number;
 
             newProposalSet();
         }

--- a/test/core/join_during_creation.js
+++ b/test/core/join_during_creation.js
@@ -20,6 +20,7 @@ const { AccountProvider } = require('../test_lib/utils.js');
 const CoreStatusUtils = require('../test_lib/core_status_utils');
 const CoreUtils = require('./utils.js');
 const Utils = require('../test_lib/utils.js');
+const web3 = require('../test_lib/web3.js');
 
 const MockCore = artifacts.require('MockCore');
 
@@ -239,6 +240,7 @@ contract('Core::joinDuringCreation', async (accounts) => {
       const validator = accountProvider.get();
       expectedUpdatedValidators.push(validator);
       expectedUpdatedReputations.push(new BN(1));
+      const expectedRootOriginObservationBlock = await web3.eth.getBlockNumber() + 1;
       await config.mockConsensus.joinDuringCreation(validator);
       const valCount = await config.mockCore.countValidators.call();
       assert.isOk(
@@ -288,6 +290,13 @@ contract('Core::joinDuringCreation', async (accounts) => {
       );
       assert.isOk(
         isProposalSetInitialized,
+      );
+
+      const actualRootOriginObservationBlock = await config.mockCore
+        .rootOriginObservationBlockHeight.call();
+      assert.strictEqual(
+        actualRootOriginObservationBlock.eqn(expectedRootOriginObservationBlock),
+        true,
       );
     });
   });

--- a/test/core/setup.js
+++ b/test/core/setup.js
@@ -184,6 +184,13 @@ contract('Core::setup', (accounts) => {
         + `and is not ${correctArgs.height}`,
       );
 
+      const openKernelHeight = await core.openKernelHeight();
+      assert.isOk(
+        openKernelHeight.cmp(correctArgs.height) === 0,
+        `Open kernel height is set to ${openKernelHeight} `
+        + `and is not ${correctArgs.height}`,
+      );
+
       const kernel = await core.kernels(correctArgs.height);
       assert.strictEqual(
         kernel.parent,


### PR DESCRIPTION
PR contains changes to add:
1. **rootOriginObservationBlockheight** storage in Core contract.
2. Initiliazing of **openKernelHeight** in setup method.
3. Updated unit test case

fixes #84 