### PR TITLE
Core getOpenKernel

### DIFF
--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -823,6 +823,22 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
     }
 
     /**
+     * It returns open kernel hash and height.
+     *
+     * @return Metablock's openKernelHash and openKernelHeight.
+     */
+    function getOpenKernel()
+        external
+        returns(bytes32 openKernelHash_, uint256 openKernelHeight_)
+    {
+        openKernelHash_ = openKernelHash;
+        openKernelHeight_ = openKernelHeight;
+    }
+
+
+    /* Public functions */
+
+    /**
      * @notice Validator is active if open kernel height is
      *           - greater or equal than validator's begin height
      *           - and, less or equal than validator's end height

--- a/contracts/core/CoreI.sol
+++ b/contracts/core/CoreI.sol
@@ -57,5 +57,7 @@ interface CoreI {
         view
         returns (bool);
 
+    function getOpenKernel() external returns (bytes32, uint256);
+
 }
 

--- a/contracts/test/core/MockCore.sol
+++ b/contracts/test/core/MockCore.sol
@@ -122,4 +122,8 @@ contract MockCore is Core {
         openKernelHeight = _openKernelHeight;
     }
 
+    function setOpenKernelHash(bytes32 _openKernelHash) public {
+        openKernelHash = _openKernelHash;
+    }
+
 }

--- a/contracts/test/core/SpyCore.sol
+++ b/contracts/test/core/SpyCore.sol
@@ -127,7 +127,7 @@ contract SpyCore is MasterCopyNonUpgradable, CoreI{
     // Note: Implementation will be done once it is required. As the method is
     // in ICore interface, we would need it, otherwise SpyCore deployment cannot
     // be done.
-    function isValidator(address _account)
+    function isValidator(address)
         external
         view
         returns (bool)

--- a/contracts/test/core/SpyCore.sol
+++ b/contracts/test/core/SpyCore.sol
@@ -134,4 +134,10 @@ contract SpyCore is MasterCopyNonUpgradable, CoreI{
     {
         require(false, "This should not be called for unit tests.");
     }
+
+    function getOpenKernel()
+        external
+        returns (bytes32, uint256) {
+        require(false, "This should not be called for unit tests.");
+    }
 }

--- a/test/core/getOpenKernel.js
+++ b/test/core/getOpenKernel.js
@@ -1,0 +1,55 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const BN = require('bn.js');
+const { AccountProvider } = require('../test_lib/utils.js');
+const Utils = require('../test_lib/utils.js');
+
+const MockCore = artifacts.require('MockCore');
+
+contract('Core::getOpenKernel', (accounts) => {
+  const accountProvider = new AccountProvider(accounts);
+  let core;
+  const kernelData = {
+    openKernelHeight: new BN(100),
+    openKernelHash: Utils.getRandomHash(),
+  };
+
+  beforeEach(async () => {
+    core = await MockCore.new();
+
+    await core.setOpenkernelHeight(kernelData.openKernelHeight, { from: accountProvider.get() });
+    await core.setOpenKernelHash(kernelData.openKernelHash, { from: accountProvider.get() });
+  });
+
+  contract('Positive Tests', async () => {
+    it('should return openkernelhash and openkernelheight ', async () => {
+      const actualKernelData = await core.getOpenKernel.call();
+
+      assert.strictEqual(
+        actualKernelData.openKernelHash_,
+        kernelData.openKernelHash,
+        'Invalid openkernelhash',
+      );
+      assert.strictEqual(
+        kernelData.openKernelHeight.eq(actualKernelData.openKernelHeight_),
+        true,
+        `Expected open kernel height value is ${kernelData.openKernelHeight} but got `
+         + `${actualKernelData.openKernelHeight_}`,
+      );
+    });
+  });
+});

--- a/test/core/getOpenKernel.js
+++ b/test/core/getOpenKernel.js
@@ -24,7 +24,7 @@ contract('Core::getOpenKernel', (accounts) => {
   const accountProvider = new AccountProvider(accounts);
   let core;
   const kernelData = {
-    openKernelHeight: new BN(100),
+    openKernelHeight: new BN(Utils.getRandomNumber(99999)),
     openKernelHash: Utils.getRandomHash(),
   };
 
@@ -36,13 +36,13 @@ contract('Core::getOpenKernel', (accounts) => {
   });
 
   contract('Positive Tests', async () => {
-    it('should return openkernelhash and openkernelheight ', async () => {
+    it('should return open kernel hash and open kernel height ', async () => {
       const actualKernelData = await core.getOpenKernel.call();
 
       assert.strictEqual(
         actualKernelData.openKernelHash_,
         kernelData.openKernelHash,
-        'Invalid openkernelhash',
+        'Invalid open kernel hash',
       );
       assert.strictEqual(
         kernelData.openKernelHeight.eq(actualKernelData.openKernelHeight_),


### PR DESCRIPTION
PR contains changes to add :
1. **getOpenKernel** method in core contract.
2. Added unit test case.

It also removes compilation warning for **isValidator** method in SpyCore contract method.

fixes #116 