### PR TITLE
Rename mOST to MOST

### DIFF
--- a/contracts/axiom/Axiom.sol
+++ b/contracts/axiom/Axiom.sol
@@ -171,7 +171,7 @@ contract Axiom is AxiomI, ProxyFactory, ConsensusModule {
      * @param _joinLimit Maximum number of validators that can join in a core.
      * @param _gasTargetDelta Gas target delta to open new metablock.
      * @param _coinbaseSplitPerMille Coinbase split per mille.
-     * @param _most most token address.
+     * @param _most MOST token address.
      * @param _stakeMOSTAmount Amount of MOST that will be staked by validators.
      * @param _wETH wEth token address.
      * @param _stakeWETHAmount Amount of wEth that will be staked by validators.

--- a/contracts/axiom/Axiom.sol
+++ b/contracts/axiom/Axiom.sol
@@ -171,8 +171,8 @@ contract Axiom is AxiomI, ProxyFactory, ConsensusModule {
      * @param _joinLimit Maximum number of validators that can join in a core.
      * @param _gasTargetDelta Gas target delta to open new metablock.
      * @param _coinbaseSplitPerMille Coinbase split per mille.
-     * @param _mOST mOST token address.
-     * @param _stakeMOSTAmount Amount of mOST that will be staked by validators.
+     * @param _most most token address.
+     * @param _stakeMOSTAmount Amount of MOST that will be staked by validators.
      * @param _wETH wEth token address.
      * @param _stakeWETHAmount Amount of wEth that will be staked by validators.
      * @param _cashableEarningsPerMille Fraction of the total amount that can
@@ -188,7 +188,7 @@ contract Axiom is AxiomI, ProxyFactory, ConsensusModule {
         uint256 _joinLimit,
         uint256 _gasTargetDelta,
         uint256 _coinbaseSplitPerMille,
-        address _mOST,
+        address _most,
         uint256 _stakeMOSTAmount,
         address _wETH,
         uint256 _stakeWETHAmount,
@@ -214,7 +214,7 @@ contract Axiom is AxiomI, ProxyFactory, ConsensusModule {
         bytes memory reputationSetupData = abi.encodeWithSelector(
             REPUTATION_SETUP_CALLPREFIX,
             consensus,
-            _mOST,
+            _most,
             _stakeMOSTAmount,
             _wETH,
             _stakeWETHAmount,

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -71,13 +71,13 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
 
     /* Storage */
 
-    /** ERC20 most for stakes and earnings for validators. */
+    /** ERC20 MOST for stakes and earnings for validators. */
     ERC20I public most;
 
     /** ERC20 wETH for stakes for validators. */
     ERC20I public wETH;
 
-    /** Required stake amount in most to stake as a validator. */
+    /** Required stake amount in MOST to stake as a validator. */
     uint256 public stakeMOSTAmount;
 
     /** Required stake amount in wETH to stake as a validator. */

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -71,13 +71,13 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
 
     /* Storage */
 
-    /** ERC20 mOST for stakes and earnings for validators. */
-    ERC20I public mOST;
+    /** ERC20 most for stakes and earnings for validators. */
+    ERC20I public most;
 
     /** ERC20 wETH for stakes for validators. */
     ERC20I public wETH;
 
-    /** Required stake amount in mOST to stake as a validator. */
+    /** Required stake amount in most to stake as a validator. */
     uint256 public stakeMOSTAmount;
 
     /** Required stake amount in wETH to stake as a validator. */
@@ -176,15 +176,15 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
 
     /**
      * @dev Function requires:
-     *          - mOST token address is not 0
+     *          - MOST token address is not 0
      *          - wETH token address is not 0
-     *          - a stake amount to stake in mOST is positive
+     *          - a stake amount to stake in MOST is positive
      *          - a stake amount to stake in wETH is positive
      *          - a cashable earnings per mille is in [0, 1000] range
      *
      * @param _consensus Address of consensus contract.
-     * @param _mOST Address of EIP20 mOST token.
-     * @param _stakeMOSTAmount Amount of mOST token in wei required to be
+     * @param _most Address of EIP20 MOST token.
+     * @param _stakeMOSTAmount Amount of MOST token in wei required to be
      *                         staked by each validator on staking.
      * @param _wETH Address of EIP20 wETH token.
      * @param _stakeWETHAmount Amount of wETH token in wei required to be
@@ -199,7 +199,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
      */
     function setup(
         ConsensusI _consensus,
-        ERC20I _mOST,
+        ERC20I _most,
         uint256 _stakeMOSTAmount,
         ERC20I _wETH,
         uint256 _stakeWETHAmount,
@@ -210,13 +210,13 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
         external
     {
         require(
-            address(mOST) == address(0) && address(wETH) == address(0),
+            address(most) == address(0) && address(wETH) == address(0),
             "Reputation is already setup."
         );
 
         require(
-            _mOST != ERC20I(0),
-            "mOST token address is 0."
+            _most != ERC20I(0),
+            "MOST token address is 0."
         );
 
         require(
@@ -226,7 +226,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
 
         require(
             _stakeMOSTAmount > 0,
-            "Stake amount in mOST is not positive."
+            "Stake amount in MOST is not positive."
         );
 
         require(
@@ -245,7 +245,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
         );
 
         setupConsensus(_consensus);
-        mOST = ERC20I(_mOST);
+        most = ERC20I(_most);
         wETH = ERC20I(_wETH);
         stakeMOSTAmount = _stakeMOSTAmount;
         stakeWETHAmount = _stakeWETHAmount;
@@ -323,7 +323,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
      * @dev Function requires:
      *          - a validator is active
      *          - a caller has approved the contract to transfer
-     *            `_amount` mOST from its address to the contract address.
+     *            `_amount` MOST from its address to the contract address.
      *
      * @param _validator A validator to deposit earnings.
      * @param _amount An amount of earnings of a validator.
@@ -346,7 +346,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
         );
 
         require(
-            mOST.transferFrom(msg.sender, address(this), _amount),
+            most.transferFrom(msg.sender, address(this), _amount),
             "Failed to transfer earnings to the contract address."
         );
     }
@@ -383,7 +383,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
         );
 
         require(
-            mOST.transfer(
+            most.transfer(
                 v.withdrawalAddress, _amount
             ),
             "Failed to transfer cashable earnings to withdrawal address."
@@ -400,7 +400,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
      *          - a validator address is not same as its withdrawal address
      *          - a validator has not staked previously
      *          - a withdrawal address has not been used as a validator address
-     *          - a validator approved in mOST token contract to transfer
+     *          - a validator approved in MOST token contract to transfer
      *            a stake amount.
      *          - a validator approved in wETH token contract to transfer
      *            a stake amount.
@@ -448,8 +448,8 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
         v.withdrawalBlockHeight = MAX_UINT256;
 
         require(
-            mOST.transferFrom(_validator, address(this), stakeMOSTAmount),
-            "Failed to transfer mOST stake amount from a validator."
+            most.transferFrom(_validator, address(this), stakeMOSTAmount),
+            "Failed to transfer MOST stake amount from a validator."
         );
 
         require(
@@ -478,14 +478,14 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
         ValidatorInfo storage v = validators[_validator];
 
         v.status = ValidatorStatus.Slashed;
-        uint256 totalmOSTAmountToBurn = v.lockedEarnings
+        uint256 totalMOSTAmountToBurn = v.lockedEarnings
             .add(v.cashableEarnings)
             .add(stakeMOSTAmount);
 
         v.lockedEarnings = 0;
         v.cashableEarnings = 0;
 
-        assert(mOST.transfer(burner, totalmOSTAmountToBurn));
+        assert(most.transfer(burner, totalMOSTAmountToBurn));
         assert(wETH.transfer(burner, stakeWETHAmount));
     }
 
@@ -541,7 +541,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
         v.cashableEarnings = 0;
 
         require(
-            mOST.transfer(
+            most.transfer(
                 v.withdrawalAddress,
                 stakeMOSTAmount.add(
                     lockedEarnings
@@ -549,7 +549,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
                     cashableEarnings
                 )
             ),
-            "Failed to withdraw staked and earned mOST amounts."
+            "Failed to withdraw staked and earned MOST amounts."
         );
 
         require(

--- a/contracts/test/reputation/SpyReputation.sol
+++ b/contracts/test/reputation/SpyReputation.sol
@@ -26,7 +26,7 @@ contract SpyReputation is MasterCopyNonUpgradable, ReputationI {
     address public validator;
 
     address public consensus;
-    address public mOST;
+    address public most;
     uint256 public stakeMOSTAmount;
     address public wETH;
     uint256 public stakeWETHAmount;
@@ -57,7 +57,7 @@ contract SpyReputation is MasterCopyNonUpgradable, ReputationI {
 
     function setup(
         address _consensus,
-        address _mOST,
+        address _most,
         uint256 _stakeMOSTAmount,
         address _wETH,
         uint256 _stakeWETHAmount,
@@ -68,7 +68,7 @@ contract SpyReputation is MasterCopyNonUpgradable, ReputationI {
         external
     {
         consensus =_consensus;
-        mOST = _mOST;
+        most = _most;
         stakeMOSTAmount =_stakeMOSTAmount;
         wETH = _wETH;
         stakeWETHAmount =_stakeWETHAmount;

--- a/test/axiom/new_committee.js
+++ b/test/axiom/new_committee.js
@@ -67,7 +67,7 @@ contract('Axiom::newCommittee', (accounts) => {
       joinLimit: new BN(10),
       gasTargetDelta: new BN(1000000000000000),
       coinbaseSplitPermille: new BN(50),
-      mOST: accountProvider.get(),
+      most: accountProvider.get(),
       stakeMOSTAmount: new BN(300000),
       wETH: accountProvider.get(),
       stakeWETHAmount: new BN(300000),

--- a/test/axiom/new_core.js
+++ b/test/axiom/new_core.js
@@ -68,7 +68,7 @@ contract('Axiom::newCore', (accounts) => {
       joinLimit: new BN(10),
       gasTargetDelta: new BN(1000000000000000),
       coinbaseSplitPermille: new BN(50),
-      mOST: accountProvider.get(),
+      most: accountProvider.get(),
       stakeMOSTAmount: new BN(300000),
       wETH: accountProvider.get(),
       stakeWETHAmount: new BN(300000),

--- a/test/axiom/new_meta_chain.js
+++ b/test/axiom/new_meta_chain.js
@@ -60,7 +60,7 @@ contract('Axiom::newMetaChain', (accounts) => {
       joinLimit: new BN(10),
       gasTargetDelta: new BN(1000000000000000),
       coinbaseSplitPermille: new BN(50),
-      mOST: accountProvider.get(),
+      most: accountProvider.get(),
       stakeMOSTAmount: new BN(300000),
       wETH: accountProvider.get(),
       stakeWETHAmount: new BN(300000),

--- a/test/axiom/setup_consensus.js
+++ b/test/axiom/setup_consensus.js
@@ -61,7 +61,7 @@ contract('Axiom::setupConsensus', (accounts) => {
       joinLimit: new BN(10),
       gasTargetDelta: new BN(1000000000000000),
       coinbaseSplitPermille: new BN(50),
-      mOST: accountProvider.get(),
+      most: accountProvider.get(),
       stakeMOSTAmount: new BN(300000),
       wETH: accountProvider.get(),
       stakeWETHAmount: new BN(300000),
@@ -217,18 +217,18 @@ contract('Axiom::setupConsensus', (accounts) => {
         'Consensus contract address is not set in the contract.',
       );
 
-      const mOST = await reputationProxyContract.mOST.call();
+      const most = await reputationProxyContract.most.call();
       assert.strictEqual(
-        mOST,
-        config.mOST,
-        'mOST contract address is not set in the contract.',
+        most,
+        config.most,
+        'MOST contract address is not set in the contract.',
       );
 
       const stakeMOSTAmount = await reputationProxyContract.stakeMOSTAmount.call();
       assert.strictEqual(
         stakeMOSTAmount.eq(config.stakeMOSTAmount),
         true,
-        'Stake mOST amount is not set in the contract.',
+        'Stake MOST amount is not set in the contract.',
       );
 
       const wETH = await reputationProxyContract.wETH.call();

--- a/test/axiom/utils.js
+++ b/test/axiom/utils.js
@@ -82,7 +82,7 @@ async function setupConsensusWithConfig(axiom, config) {
     config.joinLimit,
     config.gasTargetDelta,
     config.coinbaseSplitPermille,
-    config.mOST,
+    config.most,
     config.stakeMOSTAmount,
     config.wETH,
     config.stakeWETHAmount,

--- a/test/reputation/cashout_earnings.js
+++ b/test/reputation/cashout_earnings.js
@@ -25,7 +25,7 @@ contract('Reputation::cashoutEarnings', (accounts) => {
   let validator;
   let accountProvider;
   let reputation;
-  let mOST;
+  let most;
   let wETH;
   let depositor;
 
@@ -35,17 +35,17 @@ contract('Reputation::cashoutEarnings', (accounts) => {
       address: accountProvider.get(),
       withdrawalAddress: accountProvider.get(),
     };
-    mOST = await MockToken.new(18, { from: validator.address });
+    most = await MockToken.new(18, { from: validator.address });
     wETH = await MockToken.new(18, { from: validator.address });
 
     depositor = accountProvider.get();
 
     const funds = '1000000000000000000000';
-    await mOST.transfer(depositor, funds, { from: validator.address });
+    await most.transfer(depositor, funds, { from: validator.address });
 
     constructorArgs = {
       consensus: accountProvider.get(),
-      mOST: mOST.address,
+      most: most.address,
       stakeMOSTAmount: 200,
       wETH: wETH.address,
       stakeWETHAmount: 100,
@@ -57,7 +57,7 @@ contract('Reputation::cashoutEarnings', (accounts) => {
     reputation = await Reputation.new();
     await reputation.setup(
       constructorArgs.consensus,
-      constructorArgs.mOST,
+      constructorArgs.most,
       constructorArgs.stakeMOSTAmount,
       constructorArgs.wETH,
       constructorArgs.stakeWETHAmount,
@@ -66,9 +66,9 @@ contract('Reputation::cashoutEarnings', (accounts) => {
       constructorArgs.withdrawalCooldownPeriodInBlocks,
     );
 
-    await mOST.approve(reputation.address, funds, { from: depositor });
+    await most.approve(reputation.address, funds, { from: depositor });
 
-    await mOST.approve(
+    await most.approve(
       reputation.address,
       constructorArgs.stakeMOSTAmount,
       { from: validator.address },
@@ -96,14 +96,14 @@ contract('Reputation::cashoutEarnings', (accounts) => {
 
   it('should cash-out earning for a validator', async () => {
     const cashOutAmount = 499;
-    const initialBalance = await mOST.balanceOf(validator.withdrawalAddress);
+    const initialBalance = await most.balanceOf(validator.withdrawalAddress);
 
     await reputation.cashOutEarnings(
       cashOutAmount,
       { from: validator.address },
     );
 
-    const finalBalance = await mOST.balanceOf(validator.withdrawalAddress);
+    const finalBalance = await most.balanceOf(validator.withdrawalAddress);
 
     assert.isOk(
       finalBalance.sub(initialBalance).eqn(cashOutAmount),
@@ -147,7 +147,7 @@ contract('Reputation::cashoutEarnings', (accounts) => {
       amount,
       { from: unknownValidator },
     ),
-    'Validator has not staked.');
+      'Validator has not staked.');
   });
 
   it('should fail for slashed validator', async () => {
@@ -162,7 +162,7 @@ contract('Reputation::cashoutEarnings', (accounts) => {
       amount,
       { from: validator.address },
     ),
-    'Validator is not honest.');
+      'Validator is not honest.');
   });
 
   it('should fail for withdrawn validator', async () => {
@@ -179,6 +179,6 @@ contract('Reputation::cashoutEarnings', (accounts) => {
       amount,
       { from: validator.address },
     ),
-    'Validator has withdrawn.');
+      'Validator has withdrawn.');
   });
 });

--- a/test/reputation/cashout_earnings.js
+++ b/test/reputation/cashout_earnings.js
@@ -147,7 +147,7 @@ contract('Reputation::cashoutEarnings', (accounts) => {
       amount,
       { from: unknownValidator },
     ),
-      'Validator has not staked.');
+    'Validator has not staked.');
   });
 
   it('should fail for slashed validator', async () => {
@@ -162,7 +162,7 @@ contract('Reputation::cashoutEarnings', (accounts) => {
       amount,
       { from: validator.address },
     ),
-      'Validator is not honest.');
+    'Validator is not honest.');
   });
 
   it('should fail for withdrawn validator', async () => {
@@ -179,6 +179,6 @@ contract('Reputation::cashoutEarnings', (accounts) => {
       amount,
       { from: validator.address },
     ),
-      'Validator has withdrawn.');
+    'Validator has withdrawn.');
   });
 });

--- a/test/reputation/decrease_reputation.js
+++ b/test/reputation/decrease_reputation.js
@@ -25,7 +25,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
   let validator;
   let accountProvider;
   let reputation;
-  let mOST;
+  let most;
   let wETH;
 
   beforeEach(async () => {
@@ -34,12 +34,12 @@ contract('Reputation::decreaseReputation', (accounts) => {
       address: accountProvider.get(),
       withdrawalAddress: accountProvider.get(),
     };
-    mOST = await MockToken.new(18, { from: validator.address });
+    most = await MockToken.new(18, { from: validator.address });
     wETH = await MockToken.new(18, { from: validator.address });
 
     constructorArgs = {
       consensus: accountProvider.get(),
-      mOST: mOST.address,
+      most: most.address,
       stakeMOSTAmount: 200,
       wETH: wETH.address,
       stakeWETHAmount: 100,
@@ -51,7 +51,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
     reputation = await Reputation.new();
     await reputation.setup(
       constructorArgs.consensus,
-      constructorArgs.mOST,
+      constructorArgs.most,
       constructorArgs.stakeMOSTAmount,
       constructorArgs.wETH,
       constructorArgs.stakeWETHAmount,
@@ -60,7 +60,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
       constructorArgs.withdrawalCooldownPeriodInBlocks,
     );
 
-    await mOST.approve(
+    await most.approve(
       reputation.address,
       constructorArgs.stakeMOSTAmount,
       { from: validator.address },
@@ -140,7 +140,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail if transaction is done by account other than consensus', async () => {
@@ -152,7 +152,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
       delta,
       { from: otherAccount },
     ),
-    'Only the consensus contract can call this function.');
+      'Only the consensus contract can call this function.');
   });
 
   it('should fail for logged out validator', async () => {
@@ -164,7 +164,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail for withdraw-ed validator', async () => {
@@ -179,7 +179,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail for slashed validator', async () => {
@@ -191,6 +191,6 @@ contract('Reputation::decreaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 });

--- a/test/reputation/decrease_reputation.js
+++ b/test/reputation/decrease_reputation.js
@@ -140,7 +140,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail if transaction is done by account other than consensus', async () => {
@@ -152,7 +152,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
       delta,
       { from: otherAccount },
     ),
-      'Only the consensus contract can call this function.');
+    'Only the consensus contract can call this function.');
   });
 
   it('should fail for logged out validator', async () => {
@@ -164,7 +164,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail for withdraw-ed validator', async () => {
@@ -179,7 +179,7 @@ contract('Reputation::decreaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail for slashed validator', async () => {
@@ -191,6 +191,6 @@ contract('Reputation::decreaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 });

--- a/test/reputation/deposit_earnings.js
+++ b/test/reputation/deposit_earnings.js
@@ -152,7 +152,7 @@ contract('Reputation::depositEarnings', (accounts) => {
       amount,
       { from: depositor },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail for slashed validator', async () => {
@@ -168,7 +168,7 @@ contract('Reputation::depositEarnings', (accounts) => {
       amount,
       { from: depositor },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail for logged out validator', async () => {
@@ -181,7 +181,7 @@ contract('Reputation::depositEarnings', (accounts) => {
       amount,
       { from: depositor },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail for withdrawn validator', async () => {
@@ -201,6 +201,6 @@ contract('Reputation::depositEarnings', (accounts) => {
       amount,
       { from: depositor },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 });

--- a/test/reputation/deposit_earnings.js
+++ b/test/reputation/deposit_earnings.js
@@ -25,7 +25,7 @@ contract('Reputation::depositEarnings', (accounts) => {
   let validator;
   let accountProvider;
   let reputation;
-  let mOST;
+  let most;
   let wETH;
   let depositor;
 
@@ -35,17 +35,17 @@ contract('Reputation::depositEarnings', (accounts) => {
       address: accountProvider.get(),
       withdrawalAddress: accountProvider.get(),
     };
-    mOST = await MockToken.new(18, { from: validator.address });
+    most = await MockToken.new(18, { from: validator.address });
     wETH = await MockToken.new(18, { from: validator.address });
 
     depositor = accountProvider.get();
 
     const funds = '1000000000000000000000';
-    await mOST.transfer(depositor, funds, { from: validator.address });
+    await most.transfer(depositor, funds, { from: validator.address });
 
     constructorArgs = {
       consensus: accountProvider.get(),
-      mOST: mOST.address,
+      most: most.address,
       stakeMOSTAmount: 200,
       wETH: wETH.address,
       stakeWETHAmount: 100,
@@ -57,7 +57,7 @@ contract('Reputation::depositEarnings', (accounts) => {
     reputation = await Reputation.new();
     await reputation.setup(
       constructorArgs.consensus,
-      constructorArgs.mOST,
+      constructorArgs.most,
       constructorArgs.stakeMOSTAmount,
       constructorArgs.wETH,
       constructorArgs.stakeWETHAmount,
@@ -66,9 +66,9 @@ contract('Reputation::depositEarnings', (accounts) => {
       constructorArgs.withdrawalCooldownPeriodInBlocks,
     );
 
-    await mOST.approve(reputation.address, funds, { from: depositor });
+    await most.approve(reputation.address, funds, { from: depositor });
 
-    await mOST.approve(
+    await most.approve(
       reputation.address,
       constructorArgs.stakeMOSTAmount,
       { from: validator.address },
@@ -104,14 +104,14 @@ contract('Reputation::depositEarnings', (accounts) => {
   it('should transfer funds to reputation contract', async () => {
     const amount = 111;
 
-    const initialBalance = await mOST.balanceOf(reputation.address);
+    const initialBalance = await most.balanceOf(reputation.address);
     await reputation.depositEarnings(
       validator.address,
       amount,
       { from: depositor },
     );
 
-    const finalBalance = await mOST.balanceOf(reputation.address);
+    const finalBalance = await most.balanceOf(reputation.address);
 
     assert.isOk(
       finalBalance.sub(initialBalance).eqn(amount),
@@ -152,7 +152,7 @@ contract('Reputation::depositEarnings', (accounts) => {
       amount,
       { from: depositor },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail for slashed validator', async () => {
@@ -168,7 +168,7 @@ contract('Reputation::depositEarnings', (accounts) => {
       amount,
       { from: depositor },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail for logged out validator', async () => {
@@ -181,7 +181,7 @@ contract('Reputation::depositEarnings', (accounts) => {
       amount,
       { from: depositor },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail for withdrawn validator', async () => {
@@ -201,6 +201,6 @@ contract('Reputation::depositEarnings', (accounts) => {
       amount,
       { from: depositor },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 });

--- a/test/reputation/deregister.js
+++ b/test/reputation/deregister.js
@@ -26,7 +26,7 @@ contract('Reputation::deregister', (accounts) => {
   let validator;
   let accountProvider;
   let reputation;
-  let mOST;
+  let most;
   let wETH;
 
   beforeEach(async () => {
@@ -35,12 +35,12 @@ contract('Reputation::deregister', (accounts) => {
       address: accountProvider.get(),
       withdrawalAddress: accountProvider.get(),
     };
-    mOST = await MockToken.new(18, { from: validator.address });
+    most = await MockToken.new(18, { from: validator.address });
     wETH = await MockToken.new(18, { from: validator.address });
 
     constructorArgs = {
       consensus: accountProvider.get(),
-      mOST: mOST.address,
+      most: most.address,
       stakeMOSTAmount: 200,
       wETH: wETH.address,
       stakeWETHAmount: 100,
@@ -52,7 +52,7 @@ contract('Reputation::deregister', (accounts) => {
     reputation = await Reputation.new();
     await reputation.setup(
       constructorArgs.consensus,
-      constructorArgs.mOST,
+      constructorArgs.most,
       constructorArgs.stakeMOSTAmount,
       constructorArgs.wETH,
       constructorArgs.stakeWETHAmount,
@@ -61,7 +61,7 @@ contract('Reputation::deregister', (accounts) => {
       constructorArgs.withdrawalCooldownPeriodInBlocks,
     );
 
-    await mOST.approve(
+    await most.approve(
       reputation.address,
       constructorArgs.stakeMOSTAmount,
       { from: validator.address },
@@ -113,7 +113,7 @@ contract('Reputation::deregister', (accounts) => {
       unknownValidator,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail if transaction is done by account other than consensus', async () => {
@@ -123,7 +123,7 @@ contract('Reputation::deregister', (accounts) => {
       validator.address,
       { from: otherAccount },
     ),
-    'Only the consensus contract can call this function.');
+      'Only the consensus contract can call this function.');
   });
 
   it('should fail for deregistered validator', async () => {
@@ -133,7 +133,7 @@ contract('Reputation::deregister', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail for withdraw-ed validator', async () => {
@@ -145,7 +145,7 @@ contract('Reputation::deregister', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail for slashed validator', async () => {
@@ -155,6 +155,6 @@ contract('Reputation::deregister', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 });

--- a/test/reputation/deregister.js
+++ b/test/reputation/deregister.js
@@ -113,7 +113,7 @@ contract('Reputation::deregister', (accounts) => {
       unknownValidator,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail if transaction is done by account other than consensus', async () => {
@@ -123,7 +123,7 @@ contract('Reputation::deregister', (accounts) => {
       validator.address,
       { from: otherAccount },
     ),
-      'Only the consensus contract can call this function.');
+    'Only the consensus contract can call this function.');
   });
 
   it('should fail for deregistered validator', async () => {
@@ -133,7 +133,7 @@ contract('Reputation::deregister', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail for withdraw-ed validator', async () => {
@@ -145,7 +145,7 @@ contract('Reputation::deregister', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail for slashed validator', async () => {
@@ -155,6 +155,6 @@ contract('Reputation::deregister', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 });

--- a/test/reputation/get_reputation.js
+++ b/test/reputation/get_reputation.js
@@ -25,7 +25,7 @@ contract('Reputation::getReputation', (accounts) => {
   let validator;
   let accountProvider;
   let reputation;
-  let mOST;
+  let most;
   let wETH;
   const increasedReputation = 100;
 
@@ -35,12 +35,12 @@ contract('Reputation::getReputation', (accounts) => {
       address: accountProvider.get(),
       withdrawalAddress: accountProvider.get(),
     };
-    mOST = await MockToken.new(18, { from: validator.address });
+    most = await MockToken.new(18, { from: validator.address });
     wETH = await MockToken.new(18, { from: validator.address });
 
     constructorArgs = {
       consensus: accountProvider.get(),
-      mOST: mOST.address,
+      most: most.address,
       stakeMOSTAmount: 200,
       wETH: wETH.address,
       stakeWETHAmount: 100,
@@ -52,7 +52,7 @@ contract('Reputation::getReputation', (accounts) => {
     reputation = await Reputation.new();
     await reputation.setup(
       constructorArgs.consensus,
-      constructorArgs.mOST,
+      constructorArgs.most,
       constructorArgs.stakeMOSTAmount,
       constructorArgs.wETH,
       constructorArgs.stakeWETHAmount,
@@ -61,7 +61,7 @@ contract('Reputation::getReputation', (accounts) => {
       constructorArgs.withdrawalCooldownPeriodInBlocks,
     );
 
-    await mOST.approve(
+    await most.approve(
       reputation.address,
       constructorArgs.stakeMOSTAmount,
       { from: validator.address },

--- a/test/reputation/increase_reputation.js
+++ b/test/reputation/increase_reputation.js
@@ -25,7 +25,7 @@ contract('Reputation::increaseReputation', (accounts) => {
   let validator;
   let accountProvider;
   let reputation;
-  let mOST;
+  let most;
   let wETH;
 
   beforeEach(async () => {
@@ -34,12 +34,12 @@ contract('Reputation::increaseReputation', (accounts) => {
       address: accountProvider.get(),
       withdrawalAddress: accountProvider.get(),
     };
-    mOST = await MockToken.new(18, { from: validator.address });
+    most = await MockToken.new(18, { from: validator.address });
     wETH = await MockToken.new(18, { from: validator.address });
 
     constructorArgs = {
       consensus: accountProvider.get(),
-      mOST: mOST.address,
+      most: most.address,
       stakeMOSTAmount: 200,
       wETH: wETH.address,
       stakeWETHAmount: 100,
@@ -51,7 +51,7 @@ contract('Reputation::increaseReputation', (accounts) => {
     reputation = await Reputation.new();
     await reputation.setup(
       constructorArgs.consensus,
-      constructorArgs.mOST,
+      constructorArgs.most,
       constructorArgs.stakeMOSTAmount,
       constructorArgs.wETH,
       constructorArgs.stakeWETHAmount,
@@ -60,7 +60,7 @@ contract('Reputation::increaseReputation', (accounts) => {
       constructorArgs.withdrawalCooldownPeriodInBlocks,
     );
 
-    await mOST.approve(
+    await most.approve(
       reputation.address,
       constructorArgs.stakeMOSTAmount,
       { from: validator.address },
@@ -122,7 +122,7 @@ contract('Reputation::increaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail if transaction is done by account other than consensus', async () => {
@@ -134,7 +134,7 @@ contract('Reputation::increaseReputation', (accounts) => {
       delta,
       { from: otherAccount },
     ),
-    'Only the consensus contract can call this function.');
+      'Only the consensus contract can call this function.');
   });
 
   it('should fail for logged out validator', async () => {
@@ -146,7 +146,7 @@ contract('Reputation::increaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail for withdraw-ed validator', async () => {
@@ -161,7 +161,7 @@ contract('Reputation::increaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 
   it('should fail for slashed validator', async () => {
@@ -173,6 +173,6 @@ contract('Reputation::increaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-    'Validator is not active.');
+      'Validator is not active.');
   });
 });

--- a/test/reputation/increase_reputation.js
+++ b/test/reputation/increase_reputation.js
@@ -122,7 +122,7 @@ contract('Reputation::increaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail if transaction is done by account other than consensus', async () => {
@@ -134,7 +134,7 @@ contract('Reputation::increaseReputation', (accounts) => {
       delta,
       { from: otherAccount },
     ),
-      'Only the consensus contract can call this function.');
+    'Only the consensus contract can call this function.');
   });
 
   it('should fail for logged out validator', async () => {
@@ -146,7 +146,7 @@ contract('Reputation::increaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail for withdraw-ed validator', async () => {
@@ -161,7 +161,7 @@ contract('Reputation::increaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 
   it('should fail for slashed validator', async () => {
@@ -173,6 +173,6 @@ contract('Reputation::increaseReputation', (accounts) => {
       delta,
       { from: constructorArgs.consensus },
     ),
-      'Validator is not active.');
+    'Validator is not active.');
   });
 });

--- a/test/reputation/setup.js
+++ b/test/reputation/setup.js
@@ -142,7 +142,7 @@ contract('Reputation::setup', (accounts) => {
         constructorArgs.initialReputation,
         constructorArgs.withdrawalCooldownPeriodInBlocks,
       ),
-      'mOST token address is 0.',
+      'MOST token address is 0.',
     );
   });
 
@@ -160,7 +160,7 @@ contract('Reputation::setup', (accounts) => {
         constructorArgs.initialReputation,
         constructorArgs.withdrawalCooldownPeriodInBlocks,
       ),
-      'Stake amount in mOST is not positive.',
+      'Stake amount in MOST is not positive.',
     );
   });
 

--- a/test/reputation/setup.js
+++ b/test/reputation/setup.js
@@ -27,7 +27,7 @@ contract('Reputation::setup', (accounts) => {
   beforeEach(async () => {
     constructorArgs = {
       consensus: accountProvider.get(),
-      mOST: accountProvider.get(),
+      most: accountProvider.get(),
       stakeMOSTAmount: 200,
       wETH: accountProvider.get(),
       stakeWETHAmount: 100,
@@ -41,7 +41,7 @@ contract('Reputation::setup', (accounts) => {
   it('should successfully construct reputation contract', async () => {
     await reputation.setup(
       constructorArgs.consensus,
-      constructorArgs.mOST,
+      constructorArgs.most,
       constructorArgs.stakeMOSTAmount,
       constructorArgs.wETH,
       constructorArgs.stakeWETHAmount,
@@ -51,7 +51,7 @@ contract('Reputation::setup', (accounts) => {
     );
 
     const consensus = await reputation.consensus.call();
-    const mOST = await reputation.mOST.call();
+    const most = await reputation.most.call();
     const wETH = await reputation.wETH.call();
     const stakeMOSTAmount = await reputation.stakeMOSTAmount.call();
     const stakeWETHAmount = await reputation.stakeWETHAmount.call();
@@ -68,9 +68,9 @@ contract('Reputation::setup', (accounts) => {
     );
 
     assert.strictEqual(
-      mOST === constructorArgs.mOST,
+      most === constructorArgs.most,
       true,
-      `mOST address is set to ${mOST} and is not ${constructorArgs.mOST}.`,
+      `MOST address is set to ${most} and is not ${constructorArgs.most}.`,
     );
 
     assert.strictEqual(
@@ -116,7 +116,7 @@ contract('Reputation::setup', (accounts) => {
     await Utils.expectRevert(
       reputation.setup(
         constructorArgs.consensus,
-        constructorArgs.mOST,
+        constructorArgs.most,
         constructorArgs.stakeMOSTAmount,
         constructorArgs.wETH,
         constructorArgs.stakeWETHAmount,
@@ -128,13 +128,13 @@ contract('Reputation::setup', (accounts) => {
     );
   });
 
-  it('should fail to construct with zero mOST address', async () => {
-    constructorArgs.mOST = NULL_ADDRESS;
+  it('should fail to construct with zero MOST address', async () => {
+    constructorArgs.most = NULL_ADDRESS;
 
     await Utils.expectRevert(
       reputation.setup(
         constructorArgs.consensus,
-        constructorArgs.mOST,
+        constructorArgs.most,
         constructorArgs.stakeMOSTAmount,
         constructorArgs.wETH,
         constructorArgs.stakeWETHAmount,
@@ -152,7 +152,7 @@ contract('Reputation::setup', (accounts) => {
     await Utils.expectRevert(
       reputation.setup(
         constructorArgs.consensus,
-        constructorArgs.mOST,
+        constructorArgs.most,
         constructorArgs.stakeMOSTAmount,
         constructorArgs.wETH,
         constructorArgs.stakeWETHAmount,
@@ -170,7 +170,7 @@ contract('Reputation::setup', (accounts) => {
     await Utils.expectRevert(
       reputation.setup(
         constructorArgs.consensus,
-        constructorArgs.mOST,
+        constructorArgs.most,
         constructorArgs.stakeMOSTAmount,
         constructorArgs.wETH,
         constructorArgs.stakeWETHAmount,
@@ -188,7 +188,7 @@ contract('Reputation::setup', (accounts) => {
     await Utils.expectRevert(
       reputation.setup(
         constructorArgs.consensus,
-        constructorArgs.mOST,
+        constructorArgs.most,
         constructorArgs.stakeMOSTAmount,
         constructorArgs.wETH,
         constructorArgs.stakeWETHAmount,
@@ -206,7 +206,7 @@ contract('Reputation::setup', (accounts) => {
     await Utils.expectRevert(
       reputation.setup(
         constructorArgs.consensus,
-        constructorArgs.mOST,
+        constructorArgs.most,
         constructorArgs.stakeMOSTAmount,
         constructorArgs.wETH,
         constructorArgs.stakeWETHAmount,
@@ -224,7 +224,7 @@ contract('Reputation::setup', (accounts) => {
     await Utils.expectRevert(
       reputation.setup(
         constructorArgs.consensus,
-        constructorArgs.mOST,
+        constructorArgs.most,
         constructorArgs.stakeMOSTAmount,
         constructorArgs.wETH,
         constructorArgs.stakeWETHAmount,

--- a/test/reputation/slash.js
+++ b/test/reputation/slash.js
@@ -121,7 +121,7 @@ contract('Reputation::slash', (accounts) => {
       validator.address,
       { from: otherAccount },
     ),
-      'Only the consensus contract can call this function.');
+    'Only the consensus contract can call this function.');
   });
 
   it.skip('should fail if validator has not joined', async () => {
@@ -131,7 +131,7 @@ contract('Reputation::slash', (accounts) => {
       otherAccount,
       { from: constructorArgs.consensus },
     ),
-      'Validator has not staked.');
+    'Validator has not staked.');
   });
 
 
@@ -144,7 +144,7 @@ contract('Reputation::slash', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-      'Validator has withdrawn.');
+    'Validator has withdrawn.');
   });
 
   it('should fail to slash already slashed validator', async () => {
@@ -157,6 +157,6 @@ contract('Reputation::slash', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-      'Validator has slashed.');
+    'Validator has slashed.');
   });
 });

--- a/test/reputation/slash.js
+++ b/test/reputation/slash.js
@@ -25,7 +25,7 @@ contract('Reputation::slash', (accounts) => {
   let validator;
   let accountProvider;
   let reputation;
-  let mOST;
+  let most;
   let wETH;
   const validatorEarnings = 101;
 
@@ -35,12 +35,12 @@ contract('Reputation::slash', (accounts) => {
       address: accountProvider.get(),
       withdrawalAddress: accountProvider.get(),
     };
-    mOST = await MockToken.new(18, { from: validator.address });
+    most = await MockToken.new(18, { from: validator.address });
     wETH = await MockToken.new(18, { from: validator.address });
 
     constructorArgs = {
       consensus: accountProvider.get(),
-      mOST: mOST.address,
+      most: most.address,
       stakeMOSTAmount: 200,
       wETH: wETH.address,
       stakeWETHAmount: 100,
@@ -52,7 +52,7 @@ contract('Reputation::slash', (accounts) => {
     reputation = await Reputation.new();
     await reputation.setup(
       constructorArgs.consensus,
-      constructorArgs.mOST,
+      constructorArgs.most,
       constructorArgs.stakeMOSTAmount,
       constructorArgs.wETH,
       constructorArgs.stakeWETHAmount,
@@ -61,7 +61,7 @@ contract('Reputation::slash', (accounts) => {
       constructorArgs.withdrawalCooldownPeriodInBlocks,
     );
 
-    await mOST.approve(
+    await most.approve(
       reputation.address,
       constructorArgs.stakeMOSTAmount,
       { from: validator.address },
@@ -79,13 +79,13 @@ contract('Reputation::slash', (accounts) => {
       { from: constructorArgs.consensus },
     );
 
-    await mOST.approve(reputation.address, validatorEarnings, { from: validator.address });
+    await most.approve(reputation.address, validatorEarnings, { from: validator.address });
     await reputation.depositEarnings(validator.address, validatorEarnings);
   });
 
   it('should be able to slash a validator', async () => {
     const beforeWETHBalance = await wETH.balanceOf(reputation.address);
-    const beforeMOSTBalance = await mOST.balanceOf(reputation.address);
+    const beforeMOSTBalance = await most.balanceOf(reputation.address);
 
     const response = await reputation.slash(
       validator.address,
@@ -93,7 +93,7 @@ contract('Reputation::slash', (accounts) => {
     );
 
     const afterWETHBalance = await wETH.balanceOf(reputation.address);
-    const afterMOSTBalance = await mOST.balanceOf(reputation.address);
+    const afterMOSTBalance = await most.balanceOf(reputation.address);
 
     assert.isOk(
       response.receipt.status,
@@ -103,13 +103,13 @@ contract('Reputation::slash', (accounts) => {
     assert.isOk(
       beforeWETHBalance.sub(afterWETHBalance).eqn(constructorArgs.stakeWETHAmount),
       `WETH staked amount must be burned expected change is balance is ${constructorArgs.stakeWETHAmount} but `
-       + `found ${beforeMOSTBalance.sub(afterWETHBalance)} `,
+      + `found ${beforeMOSTBalance.sub(afterWETHBalance)} `,
     );
 
     assert.isOk(
       beforeMOSTBalance.sub(afterMOSTBalance)
         .eqn(constructorArgs.stakeMOSTAmount + validatorEarnings),
-      `mOST staked amount and earning must be burned expected change is balance is ${constructorArgs.stakeMOSTAmount + validatorEarnings} but `
+      `MOST staked amount and earning must be burned expected change is balance is ${constructorArgs.stakeMOSTAmount + validatorEarnings} but `
       + `found ${beforeMOSTBalance.sub(afterWETHBalance)} `,
     );
   });
@@ -121,7 +121,7 @@ contract('Reputation::slash', (accounts) => {
       validator.address,
       { from: otherAccount },
     ),
-    'Only the consensus contract can call this function.');
+      'Only the consensus contract can call this function.');
   });
 
   it.skip('should fail if validator has not joined', async () => {
@@ -131,7 +131,7 @@ contract('Reputation::slash', (accounts) => {
       otherAccount,
       { from: constructorArgs.consensus },
     ),
-    'Validator has not staked.');
+      'Validator has not staked.');
   });
 
 
@@ -144,7 +144,7 @@ contract('Reputation::slash', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator has withdrawn.');
+      'Validator has withdrawn.');
   });
 
   it('should fail to slash already slashed validator', async () => {
@@ -157,6 +157,6 @@ contract('Reputation::slash', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator has slashed.');
+      'Validator has slashed.');
   });
 });

--- a/test/reputation/stake.js
+++ b/test/reputation/stake.js
@@ -169,7 +169,8 @@ contract('Reputation::stake', (accounts) => {
         validator.withdrawalAddress,
         { from: nonConsensusAddress },
       ),
-      'Only the consensus contract can call this function.');
+      'Only the consensus contract can call this function.',
+    );
   });
   it('should fail to stake validator pool if MOST token is not approved', async () => {
     await most.approve(
@@ -209,7 +210,7 @@ contract('Reputation::stake', (accounts) => {
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
     ),
-      'Validator address is 0.');
+    'Validator address is 0.');
   });
 
   it('should fail for zero withdrawal address', async () => {
@@ -218,7 +219,7 @@ contract('Reputation::stake', (accounts) => {
       NULL_ADDRESS,
       { from: constructorArgs.consensus },
     ),
-      'Validator\'s withdrawal address is 0.');
+    'Validator\'s withdrawal address is 0.');
   });
 
   it('should fail if validator address is same as withdrawal address', async () => {
@@ -227,7 +228,7 @@ contract('Reputation::stake', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-      'Validator\'s address is the same as its withdrawal address.');
+    'Validator\'s address is the same as its withdrawal address.');
   });
 
   it('should fail if validator has already staked', async () => {
@@ -242,7 +243,7 @@ contract('Reputation::stake', (accounts) => {
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
     ),
-      'No validator can stake again.');
+    'No validator can stake again.');
   });
 
   it('should fail if withdrawal address has already staked as validator', async () => {
@@ -278,6 +279,6 @@ contract('Reputation::stake', (accounts) => {
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
     ),
-      'The specified withdrawal address was registered as validator.');
+    'The specified withdrawal address was registered as validator.');
   });
 });

--- a/test/reputation/stake.js
+++ b/test/reputation/stake.js
@@ -28,7 +28,7 @@ contract('Reputation::stake', (accounts) => {
   let validator;
   let accountProvider;
   let reputation;
-  let mOST;
+  let most;
   let wETH;
 
   beforeEach(async () => {
@@ -37,13 +37,13 @@ contract('Reputation::stake', (accounts) => {
       address: accountProvider.get(),
       withdrawalAddress: accountProvider.get(),
     };
-    mOST = await MockToken.new(18, { from: validator.address });
+    most = await MockToken.new(18, { from: validator.address });
     wETH = await MockToken.new(18, { from: validator.address });
 
 
     constructorArgs = {
       consensus: accountProvider.get(),
-      mOST: mOST.address,
+      most: most.address,
       stakeMOSTAmount: 200,
       wETH: wETH.address,
       stakeWETHAmount: 100,
@@ -55,7 +55,7 @@ contract('Reputation::stake', (accounts) => {
     reputation = await Reputation.new();
     await reputation.setup(
       constructorArgs.consensus,
-      constructorArgs.mOST,
+      constructorArgs.most,
       constructorArgs.stakeMOSTAmount,
       constructorArgs.wETH,
       constructorArgs.stakeWETHAmount,
@@ -64,7 +64,7 @@ contract('Reputation::stake', (accounts) => {
       constructorArgs.withdrawalCooldownPeriodInBlocks,
     );
 
-    await mOST.approve(
+    await most.approve(
       reputation.address,
       constructorArgs.stakeMOSTAmount,
       { from: validator.address },
@@ -112,7 +112,7 @@ contract('Reputation::stake', (accounts) => {
     assert.isOk(
       validatorObject.reputation.eqn(constructorArgs.initialReputation),
       `Initial reputation should be ${constructorArgs.initialReputation.toString(10)}`
-        + ` but found ${validatorObject.reputation.toString(10)}`,
+      + ` but found ${validatorObject.reputation.toString(10)}`,
     );
 
     assert.strictEqual(
@@ -146,12 +146,12 @@ contract('Reputation::stake', (accounts) => {
       { from: constructorArgs.consensus },
     );
 
-    const reputationMOSTBalance = await mOST.balanceOf.call(reputation.address);
+    const reputationMOSTBalance = await most.balanceOf.call(reputation.address);
     const reputationWETHBalance = await wETH.balanceOf.call(reputation.address);
 
     assert.isOk(
       reputationMOSTBalance.eqn(constructorArgs.stakeMOSTAmount),
-      `Expected mOST balance is ${constructorArgs.stakeMOSTAmount} but found ${reputationMOSTBalance.toString(10)}`,
+      `Expected MOST balance is ${constructorArgs.stakeMOSTAmount} but found ${reputationMOSTBalance.toString(10)}`,
     );
 
     assert.isOk(
@@ -163,15 +163,16 @@ contract('Reputation::stake', (accounts) => {
   it('should fail in non consensus address tries to stake a validator', async () => {
     const nonConsensusAddress = accountProvider.get();
 
-    await Utils.expectRevert(reputation.stake(
-      validator.address,
-      validator.withdrawalAddress,
-      { from: nonConsensusAddress },
-    ),
-    'Only the consensus contract can call this function.');
+    await Utils.expectRevert(
+      reputation.stake(
+        validator.address,
+        validator.withdrawalAddress,
+        { from: nonConsensusAddress },
+      ),
+      'Only the consensus contract can call this function.');
   });
-  it('should fail to stake validator pool if mOST token is not approved', async () => {
-    await mOST.approve(
+  it('should fail to stake validator pool if MOST token is not approved', async () => {
+    await most.approve(
       reputation.address,
       '0',
       { from: validator.address },
@@ -208,7 +209,7 @@ contract('Reputation::stake', (accounts) => {
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
     ),
-    'Validator address is 0.');
+      'Validator address is 0.');
   });
 
   it('should fail for zero withdrawal address', async () => {
@@ -217,7 +218,7 @@ contract('Reputation::stake', (accounts) => {
       NULL_ADDRESS,
       { from: constructorArgs.consensus },
     ),
-    'Validator\'s withdrawal address is 0.');
+      'Validator\'s withdrawal address is 0.');
   });
 
   it('should fail if validator address is same as withdrawal address', async () => {
@@ -226,7 +227,7 @@ contract('Reputation::stake', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator\'s address is the same as its withdrawal address.');
+      'Validator\'s address is the same as its withdrawal address.');
   });
 
   it('should fail if validator has already staked', async () => {
@@ -241,11 +242,11 @@ contract('Reputation::stake', (accounts) => {
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
     ),
-    'No validator can stake again.');
+      'No validator can stake again.');
   });
 
   it('should fail if withdrawal address has already staked as validator', async () => {
-    await mOST.transfer(
+    await most.transfer(
       validator.withdrawalAddress,
       constructorArgs.stakeMOSTAmount,
       { from: validator.address },
@@ -256,7 +257,7 @@ contract('Reputation::stake', (accounts) => {
       { from: validator.address },
     );
 
-    await mOST.approve(
+    await most.approve(
       reputation.address,
       constructorArgs.stakeMOSTAmount,
       { from: validator.withdrawalAddress },
@@ -277,6 +278,6 @@ contract('Reputation::stake', (accounts) => {
       validator.withdrawalAddress,
       { from: constructorArgs.consensus },
     ),
-    'The specified withdrawal address was registered as validator.');
+      'The specified withdrawal address was registered as validator.');
   });
 });

--- a/test/reputation/withdraw.js
+++ b/test/reputation/withdraw.js
@@ -150,7 +150,7 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-      'Validator has not deregistered.');
+    'Validator has not deregistered.');
   });
 
   it('should fail to withdraw if validator is not logged out', async () => {
@@ -158,7 +158,7 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-      'Validator has not deregistered.');
+    'Validator has not deregistered.');
   });
 
   it('should fail to withdraw if validator is slashed', async () => {
@@ -176,7 +176,7 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-      'Validator has not deregistered.');
+    'Validator has not deregistered.');
   });
 
   it('should fail to withdraw if cool down period has not elapsed', async () => {
@@ -189,7 +189,7 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-      'Withdrawal cooldown period has not elapsed.');
+    'Withdrawal cooldown period has not elapsed.');
   });
 
   it('should fail if validator is already withdrawn', async () => {
@@ -209,6 +209,6 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-      'Validator has withdrawn.');
+    'Validator has withdrawn.');
   });
 });

--- a/test/reputation/withdraw.js
+++ b/test/reputation/withdraw.js
@@ -26,7 +26,7 @@ contract('Reputation::withdraw', (accounts) => {
   let validator;
   let accountProvider;
   let reputation;
-  let mOST;
+  let most;
   let wETH;
   const validatorEarnings = 101;
 
@@ -36,12 +36,12 @@ contract('Reputation::withdraw', (accounts) => {
       address: accountProvider.get(),
       withdrawalAddress: accountProvider.get(),
     };
-    mOST = await MockToken.new(18, { from: validator.address });
+    most = await MockToken.new(18, { from: validator.address });
     wETH = await MockToken.new(18, { from: validator.address });
 
     constructorArgs = {
       consensus: accountProvider.get(),
-      mOST: mOST.address,
+      most: most.address,
       stakeMOSTAmount: 200,
       wETH: wETH.address,
       stakeWETHAmount: 100,
@@ -53,7 +53,7 @@ contract('Reputation::withdraw', (accounts) => {
     reputation = await Reputation.new();
     await reputation.setup(
       constructorArgs.consensus,
-      constructorArgs.mOST,
+      constructorArgs.most,
       constructorArgs.stakeMOSTAmount,
       constructorArgs.wETH,
       constructorArgs.stakeWETHAmount,
@@ -62,7 +62,7 @@ contract('Reputation::withdraw', (accounts) => {
       constructorArgs.withdrawalCooldownPeriodInBlocks,
     );
 
-    await mOST.approve(
+    await most.approve(
       reputation.address,
       constructorArgs.stakeMOSTAmount,
       { from: validator.address },
@@ -108,9 +108,9 @@ contract('Reputation::withdraw', (accounts) => {
 
   it('should receive funds after withdrawal', async () => {
     const beforeWETHBalance = await wETH.balanceOf(validator.withdrawalAddress);
-    const beforeMOSTBalance = await mOST.balanceOf(validator.withdrawalAddress);
+    const beforeMOSTBalance = await most.balanceOf(validator.withdrawalAddress);
 
-    await mOST.approve(reputation.address, validatorEarnings, { from: validator.address });
+    await most.approve(reputation.address, validatorEarnings, { from: validator.address });
     await reputation.depositEarnings(validator.address, validatorEarnings);
 
     await reputation.deregister(
@@ -126,7 +126,7 @@ contract('Reputation::withdraw', (accounts) => {
     );
 
     const afterWETHBalance = await wETH.balanceOf(validator.withdrawalAddress);
-    const afterMOSTBalance = await mOST.balanceOf(validator.withdrawalAddress);
+    const afterMOSTBalance = await most.balanceOf(validator.withdrawalAddress);
 
     const diffInWETHBalance = afterWETHBalance.sub(beforeWETHBalance);
     const diffInMOSTBalance = afterMOSTBalance.sub(beforeMOSTBalance);
@@ -150,7 +150,7 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator has not deregistered.');
+      'Validator has not deregistered.');
   });
 
   it('should fail to withdraw if validator is not logged out', async () => {
@@ -158,7 +158,7 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator has not deregistered.');
+      'Validator has not deregistered.');
   });
 
   it('should fail to withdraw if validator is slashed', async () => {
@@ -176,7 +176,7 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator has not deregistered.');
+      'Validator has not deregistered.');
   });
 
   it('should fail to withdraw if cool down period has not elapsed', async () => {
@@ -189,7 +189,7 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Withdrawal cooldown period has not elapsed.');
+      'Withdrawal cooldown period has not elapsed.');
   });
 
   it('should fail if validator is already withdrawn', async () => {
@@ -209,6 +209,6 @@ contract('Reputation::withdraw', (accounts) => {
       validator.address,
       { from: constructorArgs.consensus },
     ),
-    'Validator has withdrawn.');
+      'Validator has withdrawn.');
   });
 });

--- a/test_integration/01_deployment/01_deploy.ts
+++ b/test_integration/01_deployment/01_deploy.ts
@@ -54,12 +54,12 @@ describe('Deployment', async () => {
 
     const { funder } = shared.origin;
 
-    const mOST = await MockToken.new(18, { from: funder });
+    const most = await MockToken.new(18, { from: funder });
     const wETH = await MockToken.new(18, { from: funder });
 
     const web3 = shared.origin.web3;
-    shared.origin.contracts.MOST.instance = Interacts.getERC20I(web3, mOST.address);
-    shared.origin.contracts.MOST.address = mOST.address;
+    shared.origin.contracts.MOST.instance = Interacts.getERC20I(web3, most.address);
+    shared.origin.contracts.MOST.address = most.address;
     shared.origin.contracts.WETH.instance = Interacts.getERC20I(web3, wETH.address);
     shared.origin.contracts.WETH.address = wETH.address;
     const erc20FundingPromises = [];
@@ -67,7 +67,7 @@ describe('Deployment', async () => {
 
     shared.origin.keys.validators.forEach((validator) => {
       erc20FundingPromises.push(
-        mOST.transfer(
+        most.transfer(
           validator.address,
           fundingAmount,
           { from: funder },


### PR DESCRIPTION
PR covers below:

- rename `mOST` to `MOST`
- Update `_most` or `most` as variable names
- Documentation is updated to use `MOST`

Fixes #129 