### PR TITLE
Updated the soldity pragma verison for all the remaining contracts

### DIFF
--- a/contracts/ERC20I.sol
+++ b/contracts/ERC20I.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/anchor/Anchor.sol
+++ b/contracts/anchor/Anchor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/committee/Committee.sol
+++ b/contracts/committee/Committee.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/committee/CommitteeI.sol
+++ b/contracts/committee/CommitteeI.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 interface CommitteeI {
 

--- a/contracts/consensus-gateway/ConsensusGatewayBase.sol
+++ b/contracts/consensus-gateway/ConsensusGatewayBase.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/consensus/CoConsensusI.sol
+++ b/contracts/consensus/CoConsensusI.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/consensus/CoConsensusModule.sol
+++ b/contracts/consensus/CoConsensusModule.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/consensus/ConsensusI.sol
+++ b/contracts/consensus/ConsensusI.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/consensus/ConsensusModule.sol
+++ b/contracts/consensus/ConsensusModule.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/consensus/CoreLifetime.sol
+++ b/contracts/consensus/CoreLifetime.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //
@@ -31,4 +31,3 @@ contract CoreLifetimeEnum {
         active
     }
 }
-

--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/core/CoreI.sol
+++ b/contracts/core/CoreI.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //
@@ -60,4 +60,3 @@ interface CoreI {
     function getOpenKernel() external returns (bytes32, uint256);
 
 }
-

--- a/contracts/core/CoreStatusEnum.sol
+++ b/contracts/core/CoreStatusEnum.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 contract CoreStatusEnum {
     /* Enum and structs */

--- a/contracts/gas-market/GasMarket.sol
+++ b/contracts/gas-market/GasMarket.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/lib/CircularBufferUint.sol
+++ b/contracts/lib/CircularBufferUint.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/lib/MerklePatriciaProof.sol
+++ b/contracts/lib/MerklePatriciaProof.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 /**
  * @title MerklePatriciaVerifier
  * @author Sam Mayo (sammayo888@gmail.com)

--- a/contracts/most/MOSTI.sol
+++ b/contracts/most/MOSTI.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/proxies/MasterCopyNonUpgradable.sol
+++ b/contracts/proxies/MasterCopyNonUpgradable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/proxies/Proxy.sol
+++ b/contracts/proxies/Proxy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 
 /// @title Proxy - Generic proxy contract allows to execute all transactions applying the code of a master contract.

--- a/contracts/proxies/ProxyFactory.sol
+++ b/contracts/proxies/ProxyFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity >=0.5.0 <0.6.0;
 import "./Proxy.sol";
 
 // TODO: add copyright + reference

--- a/contracts/reputation/ReputationI.sol
+++ b/contracts/reputation/ReputationI.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //
@@ -28,4 +28,3 @@ interface ReputationI {
 
     function getReputation(address _validator) external view returns (uint256);
 }
-

--- a/contracts/test/anchor/SpyAnchor.sol
+++ b/contracts/test/anchor/SpyAnchor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 import "../../anchor/AnchorI.sol";
 import "../../consensus/ConsensusI.sol";

--- a/contracts/test/axiom/AxiomTest.sol
+++ b/contracts/test/axiom/AxiomTest.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/test/axiom/SpyAxiom.sol
+++ b/contracts/test/axiom/SpyAxiom.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 import "../../axiom/AxiomI.sol";
 import "../../consensus/Consensus.sol";

--- a/contracts/test/circular_buffer_uint/CircularBufferUintTest.sol
+++ b/contracts/test/circular_buffer_uint/CircularBufferUintTest.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 import "../../lib/CircularBufferUint.sol";
 

--- a/contracts/test/committee/CommitteeMockConsensus.sol
+++ b/contracts/test/committee/CommitteeMockConsensus.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/test/committee/SpyCommittee.sol
+++ b/contracts/test/committee/SpyCommittee.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 import "../../proxies/MasterCopyNonUpgradable.sol";
 import "../../committee/CommitteeI.sol";

--- a/contracts/test/consensus/ConsensusModuleTest.sol
+++ b/contracts/test/consensus/ConsensusModuleTest.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 import "../../consensus/ConsensusModule.sol";
 

--- a/contracts/test/consensus/ConsensusTest.sol
+++ b/contracts/test/consensus/ConsensusTest.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/test/consensus/MockConsensus.sol
+++ b/contracts/test/consensus/MockConsensus.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/test/consensus/SpyConsensus.sol
+++ b/contracts/test/consensus/SpyConsensus.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 import "../../proxies/MasterCopyNonUpgradable.sol";
 import "../../consensus/ConsensusI.sol";

--- a/contracts/test/consensus_gateway/SpyConsensusGateway.sol
+++ b/contracts/test/consensus_gateway/SpyConsensusGateway.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/test/consensus_gateway_base/ConsensusGatewayBaseTest.sol
+++ b/contracts/test/consensus_gateway_base/ConsensusGatewayBaseTest.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/test/core/MockCore.sol
+++ b/contracts/test/core/MockCore.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/test/core/SpyCore.sol
+++ b/contracts/test/core/SpyCore.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 import "../../core/CoreI.sol";
 import "../../proxies/MasterCopyNonUpgradable.sol";

--- a/contracts/test/proxies/MockMasterCopy.sol
+++ b/contracts/test/proxies/MockMasterCopy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 import "../../proxies/MasterCopyNonUpgradable.sol";
 

--- a/contracts/test/reputation/SpyReputation.sol
+++ b/contracts/test/reputation/SpyReputation.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 import "../../reputation/ReputationI.sol";
 

--- a/contracts/test/token/MockToken.sol
+++ b/contracts/test/token/MockToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //

--- a/contracts/test/token/MockTokenConfig.sol
+++ b/contracts/test/token/MockTokenConfig.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //
@@ -13,9 +13,9 @@ pragma solidity ^0.5.0;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // ----------------------------------------------------------------------------
-// Contracts: MockTokenConfig 
+// Contracts: MockTokenConfig
 //
 // http://www.simpletoken.org/
 //

--- a/contracts/truffle/Migrations.sol
+++ b/contracts/truffle/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 contract Migrations {
 

--- a/contracts/version/MosaicVersion.sol
+++ b/contracts/version/MosaicVersion.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.5.0 <0.6.0;
 
 // Copyright 2019 OpenST Ltd.
 //


### PR DESCRIPTION
This PR contains updates to:
- The pragma solidity version for all the remaining contracts set to `pragma solidity >=0.5.0 <0.6.0;`

Fixes #144 