### PR TITLE
Emit MetablockProposed event in Core.proposeMetablock

### DIFF
--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -32,7 +32,7 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
 
     /* Events */
 
-    /* Emitted when new metablock is proposed */
+    /** Emitted when new metablock is proposed */
     event MetablockProposed(bytes32 proposal);
 
     /* Structs */

--- a/contracts/core/Core.sol
+++ b/contracts/core/Core.sol
@@ -25,7 +25,15 @@ import "../proxies/MasterCopyNonUpgradable.sol";
 
 contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreStatusEnum, CoreI {
 
+    /* Usings */
+
     using SafeMath for uint256;
+
+
+    /* Events */
+
+    /* Emitted when new metablock is proposed */
+    event MetablockProposed(bytes32 proposal);
 
     /* Structs */
 
@@ -473,6 +481,8 @@ contract Core is MasterCopyNonUpgradable, ConsensusModule, MosaicVersion, CoreSt
 
         // insert proposal, reverts if proposal already inserted
         insertProposal(_dynasty, proposal_);
+
+        emit MetablockProposed(proposal_);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm run test:contracts",
     "test:contracts": "truffle test",
     "test:integration": "cd test_integration && tsc && ./main.sh",
-    "test:dev": "truffle test test/core/propose_metablock.js",
+    "test:dev": "truffle test test/consensus/commit.js",
     "ganache-cli": "./tools/run_ganache_cli.sh",
     "make:all": "lint:sol:solium && lint:js && compile:all && test:contracts",
     "clean": "rm -r contract_build/contracts.json interacts/* build/* 2> /dev/null || true",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm run test:contracts",
     "test:contracts": "truffle test",
     "test:integration": "cd test_integration && tsc && ./main.sh",
-    "test:dev": "truffle test test/consensus/commit.js",
+    "test:dev": "truffle test test/core/propose_metablock.js",
     "ganache-cli": "./tools/run_ganache_cli.sh",
     "make:all": "lint:sol:solium && lint:js && compile:all && test:contracts",
     "clean": "rm -r contract_build/contracts.json interacts/* build/* 2> /dev/null || true",


### PR DESCRIPTION
Validators need to know when they can start to register their votes on Core. Validators can subscribe to this event(entity) and when this event is emitted, the signatures that were created during the flow of ProtoCore can be used in register votes.

- Emits an event with bytes32 proposal value in Core.proposeMetablock method. 
```
emit MetablockProposed(bytes32 proposal)
```

Fixes #65 