### PR TITLE
MOST interface burn from

### DIFF
--- a/contracts/consensus-gateway/ConsensusGatewayBase.sol
+++ b/contracts/consensus-gateway/ConsensusGatewayBase.sol
@@ -47,6 +47,7 @@ contract ConsensusGatewayBase {
         bytes32 _kernelHash
     )
         public
+        pure
         returns(bytes32 kernelIntentHash_)
     {
         kernelIntentHash_ = keccak256(

--- a/contracts/most/MOSTI.sol
+++ b/contracts/most/MOSTI.sol
@@ -34,9 +34,9 @@ interface MOSTI {
         returns(bool);
 
     /**
-     * Burns the given amount(in wei) by msg.sender.
+     * Burns the given amount(in atto) by msg.sender.
      *
-     * @param _amount Amount in wei.
+     * @param _amount Amount in atto.
      *
      * @return bool `true` if success else `false`.
      */
@@ -45,14 +45,14 @@ interface MOSTI {
         returns(bool);
 
     /**
-     * Burns the given amount(in wei) of the given account.
+     * Burns the given amount(in atto) of the given account.
      *
      * @param _account Address of account for which the tokens will be burned.
-     * @param _amount Amount in wei.
+     * @param _amount Amount in atto.
      *
      * @return bool `true` if success else `false`.
      */
-    function burnFrom(address _account,uint256 _amount)
+    function burnFrom(address _account, uint256 _amount)
         external
         returns(bool);
 

--- a/contracts/most/MOSTI.sol
+++ b/contracts/most/MOSTI.sol
@@ -44,4 +44,16 @@ interface MOSTI {
         external
         returns(bool);
 
+    /**
+     * Burns the given amount(in wei) of the given account.
+     *
+     * @param _account Address of account for which the tokens will be burned.
+     * @param _amount Amount in wei.
+     *
+     * @return bool `true` if success else `false`.
+     */
+    function burnFrom(address _account,uint256 _amount)
+        external
+        returns(bool);
+
 }


### PR DESCRIPTION
- Added `burnFrom` to the MOST interface (Fixes #150)
and 
- Updated the state mutability of `hashKernelIntent` function to pure