### PR TITLE
Implementation of MessageBox::hashChannelIdentifier and MessageBox::hashMessage functions

### DIFF
--- a/contracts/consensus-gateway/ConsensusCogateway.sol
+++ b/contracts/consensus-gateway/ConsensusCogateway.sol
@@ -67,8 +67,7 @@ contract ConsensusCogateway is MasterCopyNonUpgradable, MessageBus, ConsensusGat
 
         MessageOutbox.setupMessageOutbox(
             _metachainId,
-            _consensusGateway,
-            address(this)
+            _consensusGateway
         );
 
         address anchor = CoConsensusI(_coConsensus).getAnchor(_metachainId);
@@ -83,9 +82,7 @@ contract ConsensusCogateway is MasterCopyNonUpgradable, MessageBus, ConsensusGat
             _consensusGateway,
             _outboxStorageIndex,
             StateRootI(anchor),
-            _maxStorageRootItems,
-            address(this)
+            _maxStorageRootItems
         );
     }
 }
-

--- a/contracts/consensus-gateway/ConsensusGateway.sol
+++ b/contracts/consensus-gateway/ConsensusGateway.sol
@@ -77,8 +77,7 @@ contract ConsensusGateway is MasterCopyNonUpgradable, MessageBus, ConsensusGatew
 
         MessageOutbox.setupMessageOutbox(
             _metachainId,
-            _consensusCogateway,
-            address(this)
+            _consensusCogateway
         );
 
         MessageInbox.setupMessageInbox(
@@ -86,8 +85,7 @@ contract ConsensusGateway is MasterCopyNonUpgradable, MessageBus, ConsensusGatew
             _consensusCogateway,
             _outboxStorageIndex,
             StateRootI(stateRootProvider),
-            _maxStorageRootItems,
-            address(this)
+            _maxStorageRootItems
         );
     }
 

--- a/contracts/message-bus/MessageBox.sol
+++ b/contracts/message-bus/MessageBox.sol
@@ -23,18 +23,63 @@ contract MessageBox is MosaicVersion {
 
     /* Constants */
 
-    /** EIP-712 domain separator name for Message bus */
-    string public constant DOMAIN_SEPARATOR_NAME = "Message-Bus";
-
-    /** EIP-712 domain separator for Message bus */
-    bytes32 public constant DOMAIN_SEPARATOR_TYPEHASH = keccak256(
-        "EIP712Domain(string name,string version,bytes32 metachainId,address verifyingContract)"
+    /** Channel type hash */
+    bytes32 public constant MMB_CHANNEL_TYPEHASH = keccak256(
+        "MosaicMessageBusChannel(address outbox, address inbox)"
     );
+
+    /** EIP-712 domain separator typehash for Mosaic bus */
+    bytes32 public constant MMB_DOMAIN_SEPARATOR_TYPEHASH = keccak256(
+        "MosaicMessageBus(string name,string version,bytes32 metachainId,bytes32 channelSeparator)"
+    );
+
+    /** EIP-712 domain separator name for Mosaic bus */
+    string public constant MMB_DOMAIN_SEPARATOR_NAME = "Mosaic-Bus";
+
+    /** Domain separator version */
+    string public constant MMB_DOMAIN_SEPARATOR_VERSION = "0";
 
     /** Message type hash */
     bytes32 public constant MESSAGE_TYPEHASH = keccak256(
         "Message(bytes32 intentHash,uint256 nonce,uint256 feeGasPrice,uint256 feeGasLimit,address sender)"
     );
+
+
+    /* Public Functions */
+
+    /**
+     * @notice Generate channel identifier hash from the input params
+     * @param _metachainId Metachain identifier.
+     * @param _outbox Outbox address.
+     * @param _inbox Inbox address.
+     */
+    function hashChannelIdentifier(
+        bytes32 _metachainId,
+        address _outbox,
+        address _inbox
+    )
+        public
+        pure
+        returns (bytes32 channelIdentifier_)
+    {
+        bytes32 channelSeparator = keccak256(
+            abi.encode(
+                MMB_CHANNEL_TYPEHASH,
+                _outbox,
+                _inbox
+            )
+        );
+
+        channelIdentifier_ = keccak256(
+            abi.encode(
+                    MMB_DOMAIN_SEPARATOR_TYPEHASH,
+                    MMB_DOMAIN_SEPARATOR_NAME,
+                    MMB_DOMAIN_SEPARATOR_VERSION,
+                    _metachainId,
+                    channelSeparator
+                )
+        );
+    }
 
 
     /* Internal functions */
@@ -46,16 +91,16 @@ contract MessageBox is MosaicVersion {
      * @param _feeGasPrice Fee gas price.
      * @param _feeGasLimit Fee gas limit.
      * @param _sender Sender address.
-     * @param _domainSeparator Domain separator
+     * @param _channelIdentifier Channel identifier.
      * @return messageHash_ Message hash.
      */
-    function messageHash(
+    function hashMessage(
         bytes32 _intentHash,
         uint256 _nonce,
         uint256 _feeGasPrice,
         uint256 _feeGasLimit,
         address _sender,
-        bytes32 _domainSeparator
+        bytes32 _channelIdentifier
     )
         internal
         pure
@@ -76,7 +121,7 @@ contract MessageBox is MosaicVersion {
             abi.encodePacked(
                 byte(0x19),
                 byte(0x4d), // 0x4d is for M (Mosaic)
-                _domainSeparator,
+                _channelIdentifier,
                 typedMessageHash
             )
         );

--- a/test/consensus-gateway/consensus_gateway/setup.js
+++ b/test/consensus-gateway/consensus_gateway/setup.js
@@ -73,13 +73,13 @@ contract('ConsensusGateway::setup', (accounts) => {
     const currentMetablockHeightFromContract = await consensusGateway
       .currentMetablockHeight.call();
     const messageInboxFromContract = await consensusGateway.messageInbox.call();
-    const outboundMessageIdentifierFromContract = await consensusGateway
-      .outboundMessageIdentifier.call();
+    const outboundChannelIdentifierFromContract = await consensusGateway
+      .outboundChannelIdentifier.call();
 
 
     const messageOutboxFromContract = await consensusGateway.messageOutbox.call();
-    const inboundMessageIdentifierFromContract = await consensusGateway
-      .inboundMessageIdentifier.call();
+    const inboundChannelIdentifierFromContract = await consensusGateway
+      .inboundChannelIdentifier.call();
 
     const inboxOffsetFromContract = await consensusGateway.INBOX_OFFSET.call();
     const outboxOffsetFromContract = await consensusGateway.OUTBOX_OFFSET.call();
@@ -118,24 +118,26 @@ contract('ConsensusGateway::setup', (accounts) => {
       `Outbox offset position must be 1 but found ${outboxOffsetFromContract.toString(10)}`,
     );
 
-    const expectedOutboundMessageIdentifier = ConsensusGatewayUtils.getMessageOutboxIdentifier(
+    const expectedOutboundChannelIdentifier = ConsensusGatewayUtils.getChannelIdentifier(
       metachainId,
       consensusGateway.address,
+      consensusCogateway,
     );
-    const expectedInboundMessageIdentifier = ConsensusGatewayUtils.getMessageInboxIdentifier(
-      metachainId,
-      consensusGateway.address,
+    assert.strictEqual(
+      expectedOutboundChannelIdentifier,
+      outboundChannelIdentifierFromContract,
+      'Outbound message identifier must match',
     );
 
-    assert.strictEqual(
-      expectedInboundMessageIdentifier,
-      inboundMessageIdentifierFromContract,
-      'Inbound message identifier must match',
+    const expectedInboundChannelIdentifier = ConsensusGatewayUtils.getChannelIdentifier(
+      metachainId,
+      consensusCogateway,
+      consensusGateway.address,
     );
     assert.strictEqual(
-      expectedOutboundMessageIdentifier,
-      outboundMessageIdentifierFromContract,
-      'Outbound message identifier must match',
+      expectedInboundChannelIdentifier,
+      inboundChannelIdentifierFromContract,
+      'Inbound message identifier must match',
     );
 
     const outboxStorageIndexFromInbox = await consensusGateway.outboxStorageIndex.call();

--- a/test/consensus-gateway/setup_consensus_cogateway.js
+++ b/test/consensus-gateway/setup_consensus_cogateway.js
@@ -66,16 +66,17 @@ contract('CoConsensusgateway::setup', (accounts) => {
         'Invalid spy metachain id',
       );
 
-      const fromContractOutBoundMessageIdentifier = await consensusCogateway
-        .outboundMessageIdentifier.call();
-      const expectedOutBoundMessageIdentifier = ConsensusGatewayUtils.getOutboundMessageIdentifier(
+      const fromContractOutBoundChannelIdentifier = await consensusCogateway
+        .outboundChannelIdentifier.call();
+      const expectedOutBoundChannelIdentifier = ConsensusGatewayUtils.getChannelIdentifier(
         setupParams.metachainId,
         consensusCogateway.address,
+        setupParams.consensusGateway,
       );
       assert.strictEqual(
-        fromContractOutBoundMessageIdentifier,
-        expectedOutBoundMessageIdentifier,
-        'Invalid outbound message identifier',
+        fromContractOutBoundChannelIdentifier,
+        expectedOutBoundChannelIdentifier,
+        'Invalid outbound channel identifier',
       );
 
       const outboxStorageIndexInContract = await consensusCogateway.outboxStorageIndex.call();
@@ -92,16 +93,17 @@ contract('CoConsensusgateway::setup', (accounts) => {
         'Invalid message outbox address',
       );
 
-      const fromContractInBoundMessageIdentifier = await consensusCogateway
-        .inboundMessageIdentifier.call();
-      const expectedInBoundMessageIdentifier = ConsensusGatewayUtils.getInboundMessageIdentifier(
+      const fromContractInBoundChannelIdentifier = await consensusCogateway
+        .inboundChannelIdentifier.call();
+      const expectedInBoundChannelIdentifier = ConsensusGatewayUtils.getChannelIdentifier(
         setupParams.metachainId,
+        setupParams.consensusGateway,
         consensusCogateway.address,
       );
       assert.strictEqual(
-        fromContractInBoundMessageIdentifier,
-        expectedInBoundMessageIdentifier,
-        'Invalid inbound message identifier',
+        fromContractInBoundChannelIdentifier,
+        expectedInBoundChannelIdentifier,
+        'Invalid inbound channel identifier',
       );
 
       const fromContractCurrentMetablockHeight = await consensusCogateway
@@ -128,4 +130,3 @@ contract('CoConsensusgateway::setup', (accounts) => {
     });
   });
 });
-

--- a/test/consensus-gateway/utils.js
+++ b/test/consensus-gateway/utils.js
@@ -4,9 +4,10 @@ const Utils = require('../test_lib/utils.js');
 const CONSENSUS_GATEWAY_INBOX_OFFSET = 4;
 const CONSENSUS_GATEWAY_OUTBOX_OFFSET = 1;
 const DEPOSIT_INTENT_TYPEHASH = web3.utils.soliditySha3('DepositIntent(uint256 amount,address beneficiary)');
-const DOMAIN_SEPARATOR_TYPEHASH = web3.utils.keccak256('EIP712Domain(string name,string version,bytes32 metachainId,address verifyingContract)');
+const CHANNEL_TYPEHASH = web3.utils.keccak256('MosaicMessageBusChannel(address outbox, address inbox)');
+const DOMAIN_SEPARATOR_TYPEHASH = web3.utils.keccak256('MosaicMessageBus(string name,string version,bytes32 metachainId,bytes32 channelSeparator)');
 const DOMAIN_SEPARATOR_VERSION = '0';
-const MESSAGE_BUS_DOMAIN_SEPARATOR_NAME = 'Message-Bus';
+const MESSAGE_BUS_DOMAIN_SEPARATOR_NAME = 'Mosaic-Bus';
 
 function getDepositIntentHash(amount, beneficiary) {
   return web3.utils.sha3(
@@ -17,78 +18,33 @@ function getDepositIntentHash(amount, beneficiary) {
   );
 }
 
-function getMessageInboxIdentifier(metachainId, verifyingAddress) {
-  return web3.utils.sha3(Utils.encodeParameters(
+function getChannelIdentifier(metachainId, outbox, inbox) {
+  const channelSeparator = web3.utils.sha3(Utils.encodeParameters(
     [
       'bytes32',
-      'string',
-      'string',
-      'bytes32',
+      'address',
       'address',
     ],
     [
-      DOMAIN_SEPARATOR_TYPEHASH,
-      MESSAGE_BUS_DOMAIN_SEPARATOR_NAME,
-      DOMAIN_SEPARATOR_VERSION,
-      metachainId,
-      verifyingAddress,
+      CHANNEL_TYPEHASH,
+      outbox,
+      inbox,
     ],
   ));
-}
-
-function getMessageOutboxIdentifier(metachainId, verifyingAddress) {
   return web3.utils.sha3(Utils.encodeParameters(
     [
       'bytes32',
       'string',
       'string',
       'bytes32',
-      'address',
+      'bytes32',
     ],
     [
       DOMAIN_SEPARATOR_TYPEHASH,
       MESSAGE_BUS_DOMAIN_SEPARATOR_NAME,
       DOMAIN_SEPARATOR_VERSION,
       metachainId,
-      verifyingAddress,
-    ],
-  ));
-}
-
-function getOutboundMessageIdentifier(metachainId, verifyingAddress) {
-  return web3.utils.sha3(Utils.encodeParameters(
-    [
-      'bytes32',
-      'string',
-      'string',
-      'bytes32',
-      'address',
-    ],
-    [
-      DOMAIN_SEPARATOR_TYPEHASH,
-      MESSAGE_BUS_DOMAIN_SEPARATOR_NAME,
-      DOMAIN_SEPARATOR_VERSION,
-      metachainId,
-      verifyingAddress,
-    ],
-  ));
-}
-
-function getInboundMessageIdentifier(metachainId, verifyingAddress) {
-  return web3.utils.sha3(Utils.encodeParameters(
-    [
-      'bytes32',
-      'string',
-      'string',
-      'bytes32',
-      'address',
-    ],
-    [
-      DOMAIN_SEPARATOR_TYPEHASH,
-      MESSAGE_BUS_DOMAIN_SEPARATOR_NAME,
-      DOMAIN_SEPARATOR_VERSION,
-      metachainId,
-      verifyingAddress,
+      channelSeparator,
     ],
   ));
 }
@@ -96,10 +52,7 @@ function getInboundMessageIdentifier(metachainId, verifyingAddress) {
 module.exports = {
   DEPOSIT_INTENT_TYPEHASH,
   getDepositIntentHash,
-  getOutboundMessageIdentifier,
-  getInboundMessageIdentifier,
-  getMessageInboxIdentifier,
-  getMessageOutboxIdentifier,
+  getChannelIdentifier,
   CONSENSUS_GATEWAY_INBOX_OFFSET,
   CONSENSUS_GATEWAY_OUTBOX_OFFSET,
 };


### PR DESCRIPTION
PR covers below:

- Implementation of hashChannelIdentifier method
```
function hashChannelIdentifier(
    bytes32 _metachainId,
    address _outbox
    address _inbox,    
) 
    public 
    pure
    returns (bytes32 channelIdentifier_) 
```

- Function `function messageHash` is renamed to `function hashMessage` 

- Interface of `setupMessageInbox` is updated since `verifyingAddress` is not needed now. Updated interface is below:
```
function setupMessageInbox(
        bytes32 _metachainId,
        address _messageOutbox,
        uint8 _outboxStorageIndex,
        StateRootI _stateRootProvider,
        uint256 _maxStorageRootItems
    )
    internal
```

- Interface of `setupMessageOutbox` is updated since `verifyingAddress` is not needed. Updated interface is below:
```
function setupMessageOutbox(
        bytes32 _metachainId,
        address _messageInbox
    )
        internal
```

Fixes #156 