### PR TITLE
Implementation of Coreputation::getReputation and Coreputation::isSlashed

### DIFF
--- a/contracts/reputation/Coreputation.sol
+++ b/contracts/reputation/Coreputation.sol
@@ -73,4 +73,35 @@ contract Coreputation is MasterCopyNonUpgradable, CoConsensusModule {
     {
         CoConsensusModule.setupCoConsensus(_coConsensus);
     }
+
+    /**
+     * @notice Returns reputation of a validator.
+     *
+     * @param _validator An address of a validator.
+     * Returns validator reputation.
+     */
+    function getReputation(address _validator)
+        external
+        view
+        returns (uint256)
+    {
+        return validators[_validator].reputation;
+    }
+
+
+    /* Public Functions */
+
+    /**
+     * @notice Check if the validator address is slashed or not.
+     *
+     * @param _validator An address of a validator.
+     * Returns true if the specified address is slashed.
+     */
+    function isSlashed(address _validator)
+        public
+        view
+        returns(bool)
+    {
+        return validators[_validator].status == ValidatorStatus.Slashed;
+    }
 }

--- a/contracts/reputation/Reputation.sol
+++ b/contracts/reputation/Reputation.sol
@@ -522,6 +522,7 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
      * @notice Returns reputation of a validator.
      *
      * @param _validator An address of a validator.
+     * Returns validator reputation.
      */
     function getReputation(address _validator)
         external
@@ -530,6 +531,9 @@ contract Reputation is MasterCopyNonUpgradable, ConsensusModule {
     {
         return validators[_validator].reputation;
     }
+
+
+    /* Public Functions */
 
     /**
      * @notice Check if the validator address is slashed or not.

--- a/contracts/test/reputation/CoreputationTest.sol
+++ b/contracts/test/reputation/CoreputationTest.sol
@@ -1,0 +1,45 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+// Copyright 2020 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "../../reputation/Coreputation.sol";
+
+/**
+ * @title TestCoreputation contract.
+ */
+contract CoreputationTest is Coreputation {
+
+    /* External functions */
+
+    function upsertValidator(
+        address _validator,
+        uint256 _reputation
+    )
+        external
+    {
+        ValidatorInfo storage vInfo = validators[_validator];
+        vInfo.status = ValidatorStatus.Staked;
+        vInfo.reputation = _reputation;
+    }
+
+    function setValidatorSlashed(
+        address _validator
+    )
+        external
+    {
+        ValidatorInfo storage vInfo = validators[_validator];
+        vInfo.status = ValidatorStatus.Slashed;
+    }
+}

--- a/test/co-reputation/get_reputation.js
+++ b/test/co-reputation/get_reputation.js
@@ -1,0 +1,48 @@
+// Copyright 2020 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const BN = require('bn.js');
+const { AccountProvider } = require('../test_lib/utils.js');
+
+const CoReputation = artifacts.require('CoreputationTest');
+
+contract('Coreputation::getReputation', (accounts) => {
+  let accountProvider;
+  let coReputation;
+  let validatorInfo;
+
+  beforeEach(async () => {
+    accountProvider = new AccountProvider(accounts);
+    coReputation = await CoReputation.new();
+    validatorInfo = {
+      validator: accountProvider.get(),
+      reputation: new BN('10'),
+    };
+    await coReputation.upsertValidator(
+      validatorInfo.validator,
+      validatorInfo.reputation,
+    );
+  });
+
+  it('should return correct reputation for a known validator', async () => {
+    const reputationValue = await coReputation.getReputation.call(validatorInfo.validator);
+    assert.strictEqual(
+      reputationValue.toString(10),
+      validatorInfo.reputation.toString(10),
+      `Expected reputation is ${validatorInfo.reputation.toString(10)} but found ${reputationValue.toString(10)}`,
+    );
+  });
+});

--- a/test/co-reputation/is_slashed.js
+++ b/test/co-reputation/is_slashed.js
@@ -1,0 +1,51 @@
+// Copyright 2020 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const BN = require('bn.js');
+const { AccountProvider } = require('../test_lib/utils.js');
+
+const CoReputation = artifacts.require('CoreputationTest');
+
+contract('Coreputation::getReputation', (accounts) => {
+  let accountProvider;
+  let coReputation;
+  let validatorInfo;
+
+  beforeEach(async () => {
+    accountProvider = new AccountProvider(accounts);
+    coReputation = await CoReputation.new();
+    validatorInfo = {
+      validator: accountProvider.get(),
+      reputation: new BN('10'),
+    };
+    await coReputation.upsertValidator(
+      validatorInfo.validator,
+      validatorInfo.reputation,
+    );
+    await coReputation.setValidatorSlashed(
+      validatorInfo.validator,
+    );
+  });
+
+  it('should return correct reputation for a known validator', async () => {
+    const isSlashed = await coReputation.isSlashed.call(validatorInfo.validator);
+    assert.strictEqual(
+      isSlashed,
+      true,
+      `Expected is true but found ${isSlashed}`,
+    );
+  });
+});


### PR DESCRIPTION
PR covers below:

Implementation of `getReputation`
    - Anyone will be able to read the reputation value of a Validator
    - Function signature:
```solidity
       function getReputation(address _validator)
           external
           view
           returns (uint256)
```
        
Implementation of `isSlashed`
    - Anyone will be able to read the boolean state of the `Slashed` property of a validator 
    - Function signature:
```solidity
       function isSlashed(address _validator)
           public
           view
           returns(bool)
```

Fixes #170 