### PR TITLE
Implement ERC20Gateway::confirmWithdraw

### DIFF
--- a/contracts/consensus-gateway/ConsensusGatewayBase.sol
+++ b/contracts/consensus-gateway/ConsensusGatewayBase.sol
@@ -31,9 +31,6 @@ contract ConsensusGatewayBase {
     /** Address of most contract on origin or auxiliary chain. */
     ERC20I public most;
 
-    /** Mapping of message sender and nonce. */
-    mapping(address => uint256) public  nonces;
-
     /** Height of current metablock */
     uint256 public currentMetablockHeight;
 

--- a/contracts/erc20-gateway/ERC20Gateway.sol
+++ b/contracts/erc20-gateway/ERC20Gateway.sol
@@ -130,7 +130,7 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
         emit GatewayProven(messageInbox, _blockNumber);
     }
 
-    /** 
+    /**
      * @notice Deposit ERC20 token to mint utility token on the auxiliary chain.
      *
      * @param _amount Amount of token to be deposited in atto
@@ -227,6 +227,8 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
     /**
      * @notice Confirm withdraw in order to transfer value token.
      *
+     * @param _utilityToken Address of utility token contract.
+     * @param _valueToken Address of value token contract.
      * @param _amount Value token amount for withdrawal.
      * @param _beneficiary Address of beneficiary where tokens will be withdrawn.
      * @param _feeGasPrice Gas price at which fee will be calculated.
@@ -240,10 +242,10 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
      *
      * @return messageHash_ Message hash.
      *
-     * \pre `_amount` is not 0.
-     * \pre `_beneficiary` address is not 0.
      * \pre `_utilityToken` address is not 0.
      * \pre `_valueToken` address is not 0.
+     * \pre `_amount` is not 0.
+     * \pre `_beneficiary` address is not 0.
      * \pre `_withdrawer` address is not 0.
      * \pre `_rlpParentNodes` is not 0.
      *
@@ -259,12 +261,12 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
      * \post Emits `WithdrawIntentConfirmed` event with the `messageHash_` parameter.
      */
     function confirmWithdraw(
+        address _utilityToken,
+        address _valueToken,
         uint256 _amount,
         address _beneficiary,
         uint256 _feeGasPrice,
         uint256 _feeGasLimit,
-        address _utilityToken,
-        address _valueToken,
         address _withdrawer,
         uint256 _blockNumber,
         bytes calldata _rlpParentNodes

--- a/contracts/erc20-gateway/ERC20Gateway.sol
+++ b/contracts/erc20-gateway/ERC20Gateway.sol
@@ -28,7 +28,7 @@ import "../ERC20I.sol";
  */
 contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
 
-    /** Events */
+    /* Events */
 
     /** Emitted when deposit intent is declared. */
     event DepositIntentDeclared(
@@ -43,7 +43,7 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
     );
 
     /** Emitted when withdraw intent is confirmed. */
-    event WithdrawIntentConfirmed ( bytes32 messageHash );
+    event WithdrawIntentConfirmed(bytes32 messageHash);
 
 
     /* Constants */
@@ -227,26 +227,26 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
     /**
      * @notice Confirm withdraw in order to transfer value token.
      *
-     * @param _utilityToken Address of utility token.
-     * @param _valueToken Address of value token.
+     * @param _utilityToken Address of utility token contract.
+     * @param _valueToken Address of value token contract.
      * @param _amount Value token amount for withdrawal.
      * @param _beneficiary Address of beneficiary where tokens will be withdrawn.
      * @param _feeGasPrice Gas price at which fee will be calculated.
      * @param _feeGasLimit Gas limit at which fee will be capped.
-     * @param _blockNumber Block number of Aux chain against which storage
+     * @param _blockNumber Block number of auxiliary chain against which storage
                            proof is generated.
      * @param _withdrawer Address of the withdrawer account.
      * @param _rlpParentNodes Storage merkle proof to verify message declaration
                               on the origin chain.
      *
-     * @return messageHash_ Message Hash
+     * @return messageHash_ Message hash.
      *
+     * \pre `_utilityToken` address is not 0.
+     * \pre `_valueToken` address is not 0.
      * \pre `_amount` is not 0.
      * \pre `_beneficiary` address is not 0.
      * \pre `_withdrawer` address is not 0.
      * \pre `_rlpParentNodes` is not 0.
-     * \pre `_utilityToken` address is not 0.
-     * \pre `_valueToken` address is not 0.
      *
      * \post Adds a new entry in `inbox` mapping storage variable. The value is
      *       set as `true` for `messagehash_` in `inbox` mapping. The
@@ -254,9 +254,10 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
      * \post Transfers the `_valueToken` token to the `msg.sender` address as a fees.
      *       The `fees` amount is calculated by `ERC20GatewayBase::reward()`
      * \post Transfer the `_valueToken` token to the `_beneficiary` address. The
-     *       transfer amount calculated as `_amount-fees`
+     *       transfer amount is calculated as `_amount-fees`
      * \post Update the nonces storage mapping variable by incrementing the
      *       value for `msg.sender` by one.
+     * \post Emits `WithdrawIntentConfirmed` event with the `messageHash_` parameter.
      */
     function confirmWithdraw(
         address _utilityToken,
@@ -275,23 +276,23 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
         uint256 initialGas = gasleft();
         require(
             _utilityToken != address(0),
-            "Utility Token address must not be 0."
+            "Utility Token address is 0."
         );
         require(
             _valueToken != address(0),
-            "Value Token address must not be 0."
+            "Value Token address is 0."
         );
         require(
             _amount != 0,
-            "Withdraw amount should be greater than 0."
+            "Withdraw amount is 0."
         );
         require(
             _beneficiary != address(0),
-            "Beneficiary address must not be 0."
+            "Beneficiary address is 0."
         );
         require(
             _withdrawer != address(0),
-            "Withdrawer address must not be 0."
+            "Withdrawer address is 0."
         );
 
         uint256 nonce = nonces[msg.sender];

--- a/contracts/erc20-gateway/ERC20Gateway.sol
+++ b/contracts/erc20-gateway/ERC20Gateway.sol
@@ -30,7 +30,7 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
     /** Events */
 
     event WithdrawIntentConfirmed ( bytes32 messageHash );
-    
+
 
     /* Constants */
 

--- a/contracts/erc20-gateway/ERC20Gateway.sol
+++ b/contracts/erc20-gateway/ERC20Gateway.sol
@@ -18,7 +18,6 @@ import "./ERC20GatewayBase.sol";
 import "../ERC20I.sol";
 import "../message-bus/MessageBus.sol";
 import "../proxies/MasterCopyNonUpgradable.sol";
-import "../ERC20I.sol";
 
 /**
  * @title ERC20Gateway Contract.
@@ -252,10 +251,13 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
      * \post Adds a new entry in `inbox` mapping storage variable. The value is
      *       set as `true` for `messagehash_` in `inbox` mapping. The
      *       `messageHash_` is calculated by `MessageInbox.confirmMessage`.
-     * \post Transfers the `_valueToken` token to the `msg.sender` address as a fees.
-     *       The `fees` amount is calculated by `ERC20GatewayBase::reward()`
-     * \post Transfer the `_valueToken` token to the `_beneficiary` address. The
-     *       transfer amount is calculated as `_amount-fees`
+     * \post Transfers the tokens to the `msg.sender` address as a fees.
+     *       The `fees` amount is calculated by calling
+     *       `ERC20GatewayBase::reward()` with parameters `gasConsumed`,
+     *       `_feeGasPrice` and `_feeGasLimit`. `gasConsumed` is the approximate
+     *       gas used in this transaction.
+     * \post Transfer the `_amount-fees` amount of token to the `_beneficiary`
+     *       address.
      * \post Update the nonces storage mapping variable by incrementing the
      *       value for `msg.sender` by one.
      * \post Emits `WithdrawIntentConfirmed` event with the `messageHash_` parameter.

--- a/contracts/erc20-gateway/ERC20Gateway.sol
+++ b/contracts/erc20-gateway/ERC20Gateway.sol
@@ -227,12 +227,11 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
     /**
      * @notice Confirm withdraw in order to transfer value token.
      *
-     * @param _utilityToken Address of utility token contract.
-     * @param _valueToken Address of value token contract.
      * @param _amount Value token amount for withdrawal.
      * @param _beneficiary Address of beneficiary where tokens will be withdrawn.
      * @param _feeGasPrice Gas price at which fee will be calculated.
      * @param _feeGasLimit Gas limit at which fee will be capped.
+     *
      * @param _blockNumber Block number of auxiliary chain against which storage
                            proof is generated.
      * @param _withdrawer Address of the withdrawer account.
@@ -241,10 +240,10 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
      *
      * @return messageHash_ Message hash.
      *
-     * \pre `_utilityToken` address is not 0.
-     * \pre `_valueToken` address is not 0.
      * \pre `_amount` is not 0.
      * \pre `_beneficiary` address is not 0.
+     * \pre `_utilityToken` address is not 0.
+     * \pre `_valueToken` address is not 0.
      * \pre `_withdrawer` address is not 0.
      * \pre `_rlpParentNodes` is not 0.
      *
@@ -260,12 +259,12 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
      * \post Emits `WithdrawIntentConfirmed` event with the `messageHash_` parameter.
      */
     function confirmWithdraw(
-        address _utilityToken,
-        address _valueToken,
         uint256 _amount,
         address _beneficiary,
         uint256 _feeGasPrice,
         uint256 _feeGasLimit,
+        address _utilityToken,
+        address _valueToken,
         address _withdrawer,
         uint256 _blockNumber,
         bytes calldata _rlpParentNodes

--- a/contracts/erc20-gateway/ERC20Gateway.sol
+++ b/contracts/erc20-gateway/ERC20Gateway.sol
@@ -30,6 +30,7 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
     /** Events */
 
     event WithdrawIntentConfirmed ( bytes32 messageHash );
+    
 
     /* Constants */
 

--- a/contracts/erc20-gateway/ERC20Gateway.sol
+++ b/contracts/erc20-gateway/ERC20Gateway.sol
@@ -43,7 +43,7 @@ contract ERC20Gateway is MasterCopyNonUpgradable, MessageBus, ERC20GatewayBase {
     );
 
     /** Emitted when withdraw intent is confirmed. */
-    event WithdrawIntentConfirmed ( bytes32 messageHash )
+    event WithdrawIntentConfirmed ( bytes32 messageHash );
 
 
     /* Constants */

--- a/contracts/erc20-gateway/ERC20GatewayBase.sol
+++ b/contracts/erc20-gateway/ERC20GatewayBase.sol
@@ -45,12 +45,6 @@ contract ERC20GatewayBase {
     mapping(address => uint256) public  nonces;
 
 
-    /* Storage */
-
-    /** Mapping of message sender and nonce. */
-    mapping(address => uint256) public  nonces;
-
-
     /* Public functions */
 
     /**

--- a/contracts/erc20-gateway/ERC20GatewayBase.sol
+++ b/contracts/erc20-gateway/ERC20GatewayBase.sol
@@ -39,6 +39,11 @@ contract ERC20GatewayBase {
         "WithdrawIntent(address valueToken,address utilityToken,uint256 amount,address beneficiary)"
     );
 
+    /* Storage */
+
+    /** Mapping of message sender and nonce. */
+    mapping(address => uint256) public  nonces;
+
 
     /* Public functions */
 

--- a/contracts/erc20-gateway/ERC20GatewayBase.sol
+++ b/contracts/erc20-gateway/ERC20GatewayBase.sol
@@ -39,10 +39,11 @@ contract ERC20GatewayBase {
         "WithdrawIntent(address valueToken,address utilityToken,uint256 amount,address beneficiary)"
     );
 
+
     /* Storage */
 
     /** Mapping of message sender and nonce. */
-    mapping(address => uint256) public  nonces;
+    mapping(address => uint256) public nonces;
 
 
     /* Public functions */


### PR DESCRIPTION
Fixes #275 

- Implements ERC20Gateway::confirmWithdraw()

- Unit tests are not included because populating value token address is necessary in proof generation for ERC20Cogateway::withdraw(). While testing, valueToken is making a transaction. Hence, it must be a live contract. It will be efficient that it can be handled in integration tests.
Same approach has been followed for consensusCogateway::confirmWithdraw. 
cc: @deepesh-kn 